### PR TITLE
Bind container /tmp to disk in mriqc/simbids (drop --writable-tmpfs)

### DIFF
--- a/clusters/test-docker.yaml
+++ b/clusters/test-docker.yaml
@@ -6,5 +6,12 @@ cluster_resources:
 
 script_preamble: |
   PATH=/opt/conda/envs/babs/bin:$PATH
+  # Supply $JOB_TMP so pipeline YAMLs can bind container /tmp to real disk with
+  # the same `-B $JOB_TMP:/tmp` line they use on real clusters (see
+  # clusters/dartmouth.yaml). Rooted at the container-writable /tmp; the SLURM
+  # array vars are set by babs's submit inside the docker-CI container.
+  export JOB_TMP="/tmp/sjob-tmp/${SLURM_ARRAY_JOB_ID}_${SLURM_ARRAY_TASK_ID}"
+  mkdir -p "${JOB_TMP}"
+  trap 'rm -rf "${JOB_TMP}"' EXIT
 
 job_compute_space: "/tmp"

--- a/pipelines/fmriprep-anat-25.2.5.yaml
+++ b/pipelines/fmriprep-anat-25.2.5.yaml
@@ -40,6 +40,10 @@ bids_app_args:
 # path doesn't auto-bind it anymore, so do it manually.
 singularity_args:
   - --containall
+  # --pwd pins CWD to the bound ds clone; without it --containall drops CWD to a
+  # tmpfs $HOME and the relative -w (.git/tmp/wkdir) overflows it -> ENOSPC. babs
+  # main doesn't emit --pwd (the old containers-run branch did). See #55.
+  - --pwd "${PWD}"
   - -B $JOB_TMP:/tmp
   - -B /dartfs/rc/lab/D/DBIC/DBIC/CON/asmacdo/templateflow:/templateflow
   - -B /dartfs/rc/lab/D/DBIC/DBIC/CON/asmacdo/mechababs/license.txt:/SGLR/FREESURFER_HOME/license.txt

--- a/pipelines/fmriprep-base-25.2.5.yaml
+++ b/pipelines/fmriprep-base-25.2.5.yaml
@@ -19,6 +19,10 @@ bids_app_args:
 
 singularity_args:
   - --containall
+  # --pwd pins CWD to the bound ds clone; without it --containall drops CWD to a
+  # tmpfs $HOME and the relative -w (.git/tmp/wkdir) overflows it -> ENOSPC. babs
+  # main doesn't emit --pwd (the old containers-run branch did). See #55.
+  - --pwd "${PWD}"
   - -B $JOB_TMP:/tmp
   - -B /dartfs/rc/lab/D/DBIC/DBIC/CON/asmacdo/templateflow:/templateflow
   - -B /dartfs/rc/lab/D/DBIC/DBIC/CON/asmacdo/mechababs/license.txt:/SGLR/FREESURFER_HOME/license.txt

--- a/pipelines/mriqc-24.0.2.yaml
+++ b/pipelines/mriqc-24.0.2.yaml
@@ -20,7 +20,15 @@ bids_app_args:
 
 singularity_args:
   - --containall
-  - --writable-tmpfs
+  # Bind container /tmp to real scratch disk. Without this, --containall leaves
+  # /tmp, $HOME, matplotlib config, and the TemplateFlow cache falling through to
+  # apptainer's small RAM overlay (~16-64 MB), which overflows -> ENOSPC while
+  # /scratch sits idle. $JOB_TMP is created + trap-cleaned by the cluster preamble.
+  - -B $JOB_TMP:/tmp
+  # mriqc pulls MNI152NLin2009cAsym for its anatomical IQM workflow; bind the
+  # pre-populated cache so it needs no writable download target.
+  - -B /dartfs/rc/lab/D/DBIC/DBIC/CON/asmacdo/templateflow:/templateflow
+  - --env TEMPLATEFLOW_HOME=/templateflow
 
 # TODO: partition/nodes/ntasks should come from cluster config, not here.
 # Resource allocation is more complex: cluster sets limits, pipeline sets

--- a/pipelines/mriqc-24.0.2.yaml
+++ b/pipelines/mriqc-24.0.2.yaml
@@ -20,10 +20,15 @@ bids_app_args:
 
 singularity_args:
   - --containall
-  # Bind container /tmp to real scratch disk. Without this, --containall leaves
-  # /tmp, $HOME, matplotlib config, and the TemplateFlow cache falling through to
-  # apptainer's small RAM overlay (~16-64 MB), which overflows -> ENOSPC while
-  # /scratch sits idle. $JOB_TMP is created + trap-cleaned by the cluster preamble.
+  # --pwd is load-bearing: under --containall, apptainer drops the working dir to
+  # a tmpfs $HOME instead of the bound ds clone. nipype's -w (.git/tmp/wkdir) is
+  # RELATIVE, so without --pwd the work dir resolves onto that tiny tmpfs and
+  # overflows -> ENOSPC while /scratch sits idle. Pin CWD to the on-scratch clone.
+  # (babs main's run template does not emit --pwd; the old containers-run branch
+  # baked it into .datalad/config, which is why fmriprep worked there. #55.)
+  - --pwd "${PWD}"
+  # Route container /tmp to real scratch disk too ($JOB_TMP is created +
+  # trap-cleaned by the cluster preamble).
   - -B $JOB_TMP:/tmp
   # mriqc pulls MNI152NLin2009cAsym for its anatomical IQM workflow; bind the
   # pre-populated cache so it needs no writable download target.

--- a/pipelines/simbids-0.0.3.yaml
+++ b/pipelines/simbids-0.0.3.yaml
@@ -23,10 +23,11 @@ bids_app_args:
 
 singularity_args:
   - --containall
-  # Bind container /tmp to real disk (the cluster axis supplies $JOB_TMP), the
-  # same mechanism the mriqc/fmriprep pipelines use. simbids' outputs are tiny
-  # and never overflow the RAM overlay, so this is for uniformity, not a fix:
-  # the docker-CI smoke test now exercises prod's exact /tmp bind path.
+  # Match the real pipelines' container setup so the docker-CI smoke test
+  # exercises prod's exact paths: --pwd pins CWD to the bound ds clone (else
+  # --containall drops it to a tmpfs $HOME and a relative -w overflows), and the
+  # $JOB_TMP:/tmp bind (cluster axis supplies $JOB_TMP) routes /tmp to disk.
+  - --pwd "${PWD}"
   - -B $JOB_TMP:/tmp
 
 all_results_in_one_zip: true

--- a/pipelines/simbids-0.0.3.yaml
+++ b/pipelines/simbids-0.0.3.yaml
@@ -23,7 +23,11 @@ bids_app_args:
 
 singularity_args:
   - --containall
-  - --writable-tmpfs
+  # Bind container /tmp to real disk (the cluster axis supplies $JOB_TMP), the
+  # same mechanism the mriqc/fmriprep pipelines use. simbids' outputs are tiny
+  # and never overflow the RAM overlay, so this is for uniformity, not a fix:
+  # the docker-CI smoke test now exercises prod's exact /tmp bind path.
+  - -B $JOB_TMP:/tmp
 
 all_results_in_one_zip: true
 zip_foldernames:


### PR DESCRIPTION
mriqc jobs died with OSError: [Errno 28] No space left on device even though /scratch was ~2% used. Under `--containall --writable-tmpfs`, apptainer routes /tmp, $HOME, matplotlib config, and the TemplateFlow cache to a small RAM overlay (~16-64 MB) that overflows almost immediately, while scratch disk sits idle.

Seen this before with fmriprep, same fix.
Fixes asmacdo/mechababs#55