### PR TITLE
docs: drop +mb1 from derivative folder name

### DIFF
--- a/docs/output_structure.md
+++ b/docs/output_structure.md
@@ -43,7 +43,7 @@ The unit of work. Each is itself a valid BIDS-study (the babs BIDS-study layout)
   code/                             # babs scaffold — run records + committed config (provenance)
   sourcedata/raw/                   # raw BIDS (submodule -> OpenNeuroDatasets)   [seam]
   derivatives/
-    <tool>-<ver>+<stage>+mb1/       # the derivative — a FOLDER in this study, NOT a separate dataset
+    <tool>-<ver>+<stage>/           # the derivative — a FOLDER in this study, NOT a separate dataset
       dataset_description.json      # DatasetType: "derivative"; GeneratedBy: [<bids_app>]
       sub-*                         # TARGET: unzipped here (today babs zips it; removing zipping lands it here — see optional-zipping / #4)
 ```


### PR DESCRIPTION
The derivative folder is <tool>-<ver>+<stage>; the +mb1 suffix read as a mechababs (executor) marker, which the fmriprepDerivatives naming convention forbids (different executors should produce identical output).