### PR TITLE
Point the repo at its new home under the CON org

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,4 +217,4 @@ For the pipeline: the **`## Pipeline`** section above (shape), the
 `pipelines/*.yaml` (flags, ground truth), and the
 `OpenNeuroDerivatives/fmriprepDerivatives` opinions repo (rationale).
 
-For current work + open issues: the GitHub tracker (`asmacdo/mechababs`).
+For current work + open issues: the GitHub tracker.

--- a/README.md
+++ b/README.md
@@ -76,10 +76,10 @@ the campaign. The split is bootstrap-vs-operate:
 need `git` + `uv` on PATH; no repo checkout required. Pipe it straight into bash:
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/asmacdo/mechababs/main/bootstrap.sh \
+curl -sSL https://raw.githubusercontent.com/con/mechababs/main/bootstrap.sh \
   | bash -s -- my-campaign \
       [--babs URL@REF]        # default: https://github.com/PennLINC/babs.git@main
-      [--mechababs URL@REF]   # default: https://github.com/asmacdo/mechababs.git@main
+      [--mechababs URL@REF]   # default: https://github.com/con/mechababs.git@main
 ```
 
 Clones the two code pins into `code/`, builds `.venv` with `uv`, makes the
@@ -282,7 +282,7 @@ To add a pipeline: copy an existing `pipelines/*.yaml`, set a unique
 - [CLAUDE.md](CLAUDE.md) — project conventions, the pipeline, terminology,
   milestones, and the working agreement.
 - [design/](design/) — architecture proposals and diagrams.
-- Open work + milestones live in the GitHub tracker (`asmacdo/mechababs`).
+- Open work + milestones live in the GitHub tracker.
 
 ## Upstream
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 BABS_DEFAULT="https://github.com/PennLINC/babs.git@main"
-MECHABABS_DEFAULT="https://github.com/asmacdo/mechababs.git@main"
+MECHABABS_DEFAULT="https://github.com/con/mechababs.git@main"
 
 usage() {
     cat <<'EOF'
@@ -18,7 +18,7 @@ Build a mechababs campaign's environment:
   - make the campaign a datalad dataset, register subdatasets
 
   --babs URL@REF          babs pin (default: PennLINC/babs main)
-  --mechababs URL@REF     mechababs pin (default: asmacdo/mechababs main)
+  --mechababs URL@REF     mechababs pin (default: con/mechababs main)
   --system-site-packages  build the venv with access to the ambient Python's
                           installed packages, reusing a pre-built heavy stack
                           instead of rebuilding it (the e2e fixture uses this on


### PR DESCRIPTION
mechababs moved from asmacdo/mechababs to con/mechababs. The pin default in bootstrap.sh matters most: it is recorded as the mechababs code URL in every campaign built afterwards, so a stale value there writes the wrong provenance rather than merely misdirecting a reader.

The two "the GitHub tracker (asmacdo/mechababs)" lines lose the repo name instead of gaining a new one. Naming the repo inside that same repo is redundant, and it is what made these rot on the move.

Closes https://github.com/con/mechababs/issues/58

Caveat: after moving, I recreated my fork (asmacdo/mechababs) which broke all the forwarding. The issues seemed to update all the crosslinks, but at least some links are broken (ie PR #77) This is unfortunate, but I dont think its too much of a problem, the backrefs are fine, just the forward links. 