### PR TITLE
pipelines: reuse anat derivatives in downstream fmriprep stages

### DIFF
--- a/examples/pipelines/fMRIPrep-25.2.5+full.yaml
+++ b/examples/pipelines/fMRIPrep-25.2.5+full.yaml
@@ -42,6 +42,13 @@ bids_app_args:
   # is real: path_in_babs is sourcedata/fMRIPrep-25.2.5+anat, and the zip's
   # top folder is also fMRIPrep-25.2.5+anat/.
   --fs-subjects-dir: '"${PWD}"/sourcedata/fMRIPrep-25.2.5+anat/fMRIPrep-25.2.5+anat/sourcedata/freesurfer'
+  # Reuse the anat stage's precomputed derivatives (fmriprep --derivatives
+  # PACKAGE=PATH) so the anatomical set is taken from anat's output rather than
+  # recomputed. Same input mount as --fs-subjects-dir above, minus the
+  # /sourcedata/freesurfer tail: this points at the anat derivative root
+  # (sub-*/anat + dataset_description.json). --fs-subjects-dir stays — FreeSurfer
+  # reuse is a separate mechanism.
+  --derivatives: 'anat="${PWD}"/sourcedata/fMRIPrep-25.2.5+anat/fMRIPrep-25.2.5+anat'
   --nprocs: "4"
   --omp-nthreads: "2"
   --mem-mb: "32000"

--- a/examples/pipelines/fMRIPrep-25.2.5+minimal.yaml
+++ b/examples/pipelines/fMRIPrep-25.2.5+minimal.yaml
@@ -58,6 +58,13 @@ bids_app_args:
   # is real: path_in_babs is sourcedata/fMRIPrep-25.2.5+anat, and the zip's
   # top folder is also fMRIPrep-25.2.5+anat/.
   --fs-subjects-dir: '"${PWD}"/sourcedata/fMRIPrep-25.2.5+anat/fMRIPrep-25.2.5+anat/sourcedata/freesurfer'
+  # Reuse the anat stage's precomputed derivatives (fmriprep --derivatives
+  # PACKAGE=PATH) so the anatomical set is taken from anat's output rather than
+  # recomputed. Same input mount as --fs-subjects-dir above, minus the
+  # /sourcedata/freesurfer tail: this points at the anat derivative root
+  # (sub-*/anat + dataset_description.json). --fs-subjects-dir stays — FreeSurfer
+  # reuse is a separate mechanism.
+  --derivatives: 'anat="${PWD}"/sourcedata/fMRIPrep-25.2.5+anat/fMRIPrep-25.2.5+anat'
   --nprocs: "4"
   --omp-nthreads: "2"
   --mem-mb: "32000"

--- a/examples/pipelines/fMRIPrep-25.2.5+resampling.yaml
+++ b/examples/pipelines/fMRIPrep-25.2.5+resampling.yaml
@@ -51,6 +51,13 @@ bids_app_args:
   # is real: path_in_babs is sourcedata/fMRIPrep-25.2.5+anat, and the zip's
   # top folder is also fMRIPrep-25.2.5+anat/.
   --fs-subjects-dir: '"${PWD}"/sourcedata/fMRIPrep-25.2.5+anat/fMRIPrep-25.2.5+anat/sourcedata/freesurfer'
+  # Reuse the anat stage's precomputed derivatives (fmriprep --derivatives
+  # PACKAGE=PATH) so the anatomical set is taken from anat's output rather than
+  # recomputed. Same input mount as --fs-subjects-dir above, minus the
+  # /sourcedata/freesurfer tail: this points at the anat derivative root
+  # (sub-*/anat + dataset_description.json). --fs-subjects-dir stays — FreeSurfer
+  # reuse is a separate mechanism.
+  --derivatives: 'anat="${PWD}"/sourcedata/fMRIPrep-25.2.5+anat/fMRIPrep-25.2.5+anat'
   --nprocs: "4"
   --omp-nthreads: "2"
   --mem-mb: "32000"


### PR DESCRIPTION
Downstream fmriprep stages (`+minimal`/`+resampling`/`+full`) consumed the anat stage's FreeSurfer (`--fs-subjects-dir`) but not its **derivatives**, so each recomputed and re-emitted a *divergent* anatomical subset — a study could carry two anat sets that differ by construction. This adds `--derivatives` so downstream stages reuse the anat output. Refs #78.

**Changes**
- Add `--derivatives anat="${PWD}"/sourcedata/fMRIPrep-25.2.5+anat/fMRIPrep-25.2.5+anat` to `+minimal`, `+resampling`, `+full`.
- Rides the existing chained-input mount (the same path `--fs-subjects-dir` already uses, minus the `/sourcedata/freesurfer` tail = the anat derivative root). No `iterate`/`merge_config` change.

**Verified** on a real cluster (ds003097, 3 subjects, anat→minimal on Unity):
- All 3 chained minimal jobs ran green.
- `+minimal/…/anat/` collapsed from the full divergent subset to just a ribbon mask + L/R fsaverage reg spheres — the study's anat now comes solely from the anat stage.
- `+minimal/…/func/` is transforms-only (HMC / coreg / SDC + boldrefs + mask), no `space-MNI*_bold` (correct for `--level minimal`).

<details><summary>anat set: anat stage vs minimal/anat with <code>--derivatives</code></summary>

| anat output | `+anat/…/anat/` | `+minimal/…/anat/` |
|---|---|---|
| MNI152NLin2009c/6 res-2 T1w + masks + dseg + probseg | full | absent (reused) |
| fsLR den-32k surfaces + den-91k dscalars | present | absent (reused) |
| aparcaseg/aseg, xfms, FreeSurfer surfaces, curv/sulc/thickness | present | absent (reused) |
| ribbon mask + L/R fsaverage reg spheres | present | only these two |

</details>

Not marking `Closes #78`: the 2-item residue minimal still emits (ribbon mask + fsaverage reg spheres) is an open question (fmriprep's derivative-reuse is flagged experimental), so leaving #78 open to track that.
