### PR TITLE
e2e: make Ctrl-C abort the podman run

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -96,6 +96,9 @@ rm -rf $MECHABABS_E2E_WORKDIR/dev-campaign-* $MECHABABS_E2E_WORKDIR/test-campaig
 `MECHABABS_E2E_KEEP=1` additionally keeps the *container*, for post-mortem of the
 container itself.
 
+**Ctrl-C aborts the run.** It stops the container and exits 130. The campaigns built so
+far stay on the host workdir, half-finished; clean them up the same way.
+
 **babs under test.** The suite runs on babs `main` by default. To test against an
 unmerged babs fix, pin a babs ref — the dev campaign pins it, and the scenario's campaign
 inherits it from those pins:

--- a/mechababs/testing/e2e/run_in_podman.sh
+++ b/mechababs/testing/e2e/run_in_podman.sh
@@ -122,7 +122,12 @@ fi
 # The dev campaign: a fresh path per run, because bootstrap refuses an existing one. The
 # scenario's own throwaway campaign lands beside it (test-cluster builds it in the
 # campaign's parent, so the shim stays its sibling).
-DEV_CAMPAIGN="$MECHABABS_E2E_WORKDIR/dev-campaign-$$-$RANDOM"
+# One id for the run, shared by the campaign path and the container name, so it is
+# obvious which container built which campaign. $RANDOM as well as $$ because PIDs are
+# recycled, and under MECHABABS_E2E_KEEP a container from an earlier run is still around
+# to collide with.
+RUN_ID="$$-$RANDOM"
+DEV_CAMPAIGN="$MECHABABS_E2E_WORKDIR/dev-campaign-$RUN_ID"
 echo "dev campaign: $DEV_CAMPAIGN (remove stale ones with" >&2
 echo "    rm -rf $MECHABABS_E2E_WORKDIR/dev-campaign-* $MECHABABS_E2E_WORKDIR/test-campaign-*)" >&2
 
@@ -132,19 +137,55 @@ echo "    rm -rf $MECHABABS_E2E_WORKDIR/dev-campaign-* $MECHABABS_E2E_WORKDIR/te
 BABS_SPEC_ENV=()
 [ -n "${BABS_SPEC:-}" ] && BABS_SPEC_ENV=(-e "BABS_SPEC=$BABS_SPEC")
 
+# The container is always NAMED, so the Ctrl-C handler below has something to address.
 # The campaigns persist on the host bind mount regardless of --rm.
-# MECHABABS_E2E_KEEP=1 additionally keeps the *container* (drops --rm, names it) for
-# post-mortem of the container itself.
+# MECHABABS_E2E_KEEP=1 additionally keeps the *container* (drops --rm) for post-mortem of
+# the container itself.
+CONTAINER="mechababs-e2e-$RUN_ID"
 RM_FLAG=(--rm)
-NAME_FLAG=()
 if [ -n "${MECHABABS_E2E_KEEP:-}" ]; then
-    CONTAINER="mechababs-e2e-$$"
     RM_FLAG=()
-    NAME_FLAG=(--name "$CONTAINER")
     echo "KEEP: container $CONTAINER persists (the campaigns are already on the host" >&2
     echo "    under $MECHABABS_E2E_WORKDIR). Remove the container with:" >&2
     echo "    podman rm $CONTAINER" >&2
 fi
+
+# Ctrl-C has to abort the run, and nothing about that is automatic here (#105). Three
+# separate things swallow the interrupt:
+#   1. Under `podman machine` (every macOS host), the podman CLI is a REMOTE client and
+#      the signal never reaches the container at all.
+#   2. Natively, podman's --sig-proxy does deliver it, but to the container's PID 1 —
+#      tini — which forwards only to its DIRECT child: the `bash -c` wrapper below.
+#      Non-interactive bash neither relays a signal to its foreground child nor runs a
+#      trap until that child returns, and here that child is the whole e2e. So the run
+#      continues to completion, which is the reported "nothing happens".
+#   3. This script would have the same problem: bash defers a trap while a FOREGROUND
+#      command runs, so a handler could not fire until podman exited on its own.
+# So don't depend on signal delivery reaching the workload. Run podman in the
+# background, `wait` for it (bash *does* interrupt `wait` to run a trap), and tear the
+# container down explicitly — killing it kills everything inside, on both podman flavors.
+# A TTY (`-t`) would fix the interactive case by giving the container a line discipline
+# to deliver SIGINT to its foreground process group, but it does nothing for a redirected
+# or CI run, and it would dress the log in pytest's terminal escapes. This works for both.
+# Both halves of the teardown are needed. Stopping the CLIENT covers an interrupt in the
+# first second or two, before the container exists: removing it by name would hit nothing,
+# and bash does not reap the backgrounded client on exit, so it would go on to create and
+# run the container unattended (verified — it reaches the end of bootstrap). Removing the
+# CONTAINER covers every later interrupt, and is what actually stops the work, since
+# pytest, babs and the inner singularity job all live inside it.
+PODMAN_PID=
+abort() {
+    echo >&2
+    echo "interrupted — stopping container $CONTAINER" >&2
+    # An `if` rather than `[ … ] && kill …`, whose non-zero status under `set -e` would
+    # skip the removal below. Empty only if the interrupt beat the assignment below.
+    if [ -n "$PODMAN_PID" ]; then
+        kill "$PODMAN_PID" 2>/dev/null || true
+    fi
+    podman rm --force --time 0 "$CONTAINER" >/dev/null 2>&1 || true
+    exit 130
+}
+trap abort INT TERM
 
 # Bootstrap the dev campaign, then validate the docker cluster config from it. Extra
 # args ("$@") pass through to test-cluster, word boundaries preserved (so e.g.
@@ -154,7 +195,7 @@ fi
 # reads an empty array's expansion as an unbound variable and aborts — and each of these
 # arrays is empty in the default case, so the plain form breaks the script outright on a
 # CentOS 7 / RHEL 7 login node (bash 4.2) or macOS's system bash 3.2.
-podman run ${RM_FLAG[@]+"${RM_FLAG[@]}"} ${NAME_FLAG[@]+"${NAME_FLAG[@]}"} -i \
+podman run ${RM_FLAG[@]+"${RM_FLAG[@]}"} --name "$CONTAINER" -i \
     --platform linux/amd64 \
     -h slurmctl \
     --security-opt label=disable \
@@ -189,4 +230,11 @@ podman run ${RM_FLAG[@]+"${RM_FLAG[@]}"} ${NAME_FLAG[@]+"${NAME_FLAG[@]}"} -i \
         . .venv/bin/activate
         mechababs test-cluster \
             --cluster /mechababs/examples/clusters/test-docker.yaml "$@"
-    ' _ "$@"
+    ' _ "$@" &
+PODMAN_PID=$!
+
+# `wait` rather than running podman in the foreground: this is the line that makes the
+# trap above prompt. Keep podman's exit code as ours, so a failed e2e still fails here.
+RC=0
+wait "$PODMAN_PID" || RC=$?
+exit "$RC"

--- a/tests/test_run_in_podman.py
+++ b/tests/test_run_in_podman.py
@@ -1,0 +1,205 @@
+"""Tests for `run_in_podman.sh`'s interrupt handling (con/mechababs#105).
+
+Ctrl-C used to have no effect on the podman rung: the interrupt never reached the
+workload, so the e2e ran to completion no matter how many times you pressed it. Nothing
+else can catch that — no test fails, the run just refuses to stop — so it needs a test
+that actually interrupts a run.
+
+These drive the REAL script against a stub `podman` on PATH, so they are hermetic and take
+about a second: no image, no container, no e2e. What keeps that honest is that the stub
+**ignores SIGINT** exactly as the real client does under `podman machine`, so a pass cannot
+be an artifact of the stub politely dying on its own.
+"""
+
+import os
+import signal
+import subprocess
+import time
+
+import pytest
+
+SCRIPT = "mechababs/testing/e2e/run_in_podman.sh"
+
+# Records one line per call, in order, plus a marker for the signals it is sent.
+#
+# `run` stands in for a long e2e and is faithful in the three ways the fix depends on: it
+# IGNORES SIGINT (the whole reason #105 happened), it dies on SIGTERM, and it lives exactly
+# as long as its container — a file under PODMAN_STATE stands in for the container, so
+# removing the container ends the client just as it does for real. Without that last part
+# the two halves of the teardown could not be told apart.
+STUB_PODMAN = """#!/usr/bin/env bash
+echo "$*" >> "$PODMAN_CALLS"
+name=""
+case "$1" in
+    run)
+        prev=""
+        for a in "$@"; do [ "$prev" = "--name" ] && name="$a"; prev="$a"; done
+        trap '' INT
+        trap 'echo "client-terminated" >> "$PODMAN_CALLS"; exit 143' TERM
+        : > "$PODMAN_STATE/$name"
+        # `sleep &` + `wait`, never a foreground sleep: bash defers a trap until a
+        # foreground command returns, which is the very trap #105 was about.
+        while [ -e "$PODMAN_STATE/$name" ]; do sleep 0.1 & wait $!; done
+        echo "container-gone" >> "$PODMAN_CALLS"
+        ;;
+    rm|kill|stop)
+        for a in "$@"; do name="$a"; done   # the container is the last argument
+        rm -f "$PODMAN_STATE/$name"
+        ;;
+esac
+exit 0
+"""
+
+
+@pytest.fixture
+def fake_checkout(tmp_path):
+    """A minimal committed checkout with the real script at its real relative path.
+
+    The script derives the repo root from its own location and refuses a dirty tree or a
+    detached HEAD, so it needs a real git repo — but not *this* one, whose tree is dirty
+    exactly when someone is working on the script.
+    """
+    repo = tmp_path / "checkout"
+    (repo / "mechababs" / "testing" / "e2e").mkdir(parents=True)
+    here = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    with open(os.path.join(here, SCRIPT), "rb") as src:
+        (repo / SCRIPT).write_bytes(src.read())
+    (repo / SCRIPT).chmod(0o755)
+
+    def git(*args):
+        subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True)
+
+    git("init", "-q", "-b", "main")
+    git("add", "-A")
+    git("-c", "user.email=t@t", "-c", "user.name=t", "commit", "-q", "-m", "script")
+    return repo
+
+
+@pytest.fixture
+def interrupted_run(tmp_path, fake_checkout):
+    """Start the script under a stub podman, Ctrl-C it, and report what it did.
+
+    SIGINT goes to the whole process group because that is what a terminal does, and the
+    bug was precisely about which member of that group acts on it. The child gets its own
+    session — never a shell's `&`, which would set SIGINT to SIG_IGN and so silently
+    disable the very trap under test.
+    """
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    (bindir / "podman").write_text(STUB_PODMAN)
+    (bindir / "podman").chmod(0o755)
+    calls_file = tmp_path / "calls.txt"
+    calls_file.touch()
+    state = tmp_path / "state"
+    state.mkdir()
+
+    def calls():
+        return calls_file.read_text().splitlines()
+
+    def run():
+        proc = subprocess.Popen(
+            [str(fake_checkout / SCRIPT)],
+            cwd=str(fake_checkout),
+            env={
+                **os.environ,
+                "PATH": f"{bindir}:{os.environ['PATH']}",
+                "PODMAN_CALLS": str(calls_file),
+                "PODMAN_STATE": str(state),
+                "MECHABABS_E2E_WORKDIR": str(tmp_path / "work"),
+            },
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            start_new_session=True,
+        )
+
+        # Interrupt only once the run is genuinely under way, which is the case the bug
+        # was about (an interrupt before that has nothing to stop).
+        if not _wait_until(lambda: any(c.startswith("run ") for c in calls()), proc):
+            proc.kill()
+            pytest.fail(f"stub podman was never asked to run:\n{proc.communicate()[0]}")
+
+        os.killpg(os.getpgid(proc.pid), signal.SIGINT)
+        try:
+            output = proc.communicate(timeout=20)[0]
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            pytest.fail(
+                "script did not exit within 20s of SIGINT — the interrupt was ignored"
+            )
+
+        # The stub's own records can land microseconds after the script exits. Short
+        # timeout: these are local file writes, so anything slower means they never came.
+        _wait_until(
+            lambda: "client-terminated" in calls() and _removals(calls()),
+            None,
+            timeout=5,
+        )
+        return proc.returncode, output, calls()
+
+    return run
+
+
+def _wait_until(predicate, proc, timeout=20):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return True
+        if proc is not None and proc.poll() is not None:
+            return predicate()
+        time.sleep(0.05)
+    return False
+
+
+def _removals(calls):
+    return [c for c in calls if c.startswith(("rm ", "kill ", "stop "))]
+
+
+def _summary(calls):
+    """The calls, minus the 20-line `podman run` argv that would bury the failure."""
+    return "\n".join(c if not c.startswith("run ") else "run …" for c in calls)
+
+
+def _container_name(calls):
+    """The name the script gave `podman run --name`."""
+    fields = next(c for c in calls if c.startswith("run ")).split()
+    return fields[fields.index("--name") + 1]
+
+
+def test_interrupt_ends_the_run(interrupted_run):
+    """#105 itself: Ctrl-C ends the run instead of being swallowed.
+
+    The stub's `run` ignores SIGINT and otherwise runs until its container goes away, so
+    an exit here can only come from the script's own handler. 130 is the
+    interrupted-by-SIGINT convention.
+    """
+    rc, output, _ = interrupted_run()
+    assert rc == 130, f"expected 130 (SIGINT), got {rc}\n{output}"
+    assert "interrupted" in output, f"no interrupt notice printed:\n{output}"
+
+
+def test_interrupt_removes_the_container_it_started(interrupted_run):
+    """Teardown must name the container the script actually started.
+
+    Removing the container is what stops the work: pytest, babs, and the inner singularity
+    job all live inside it, and no signal the host sends reaches them.
+    """
+    _, output, calls = interrupted_run()
+    name = _container_name(calls)
+    assert any(name in c for c in _removals(calls)), (
+        f"container {name} was never torn down; podman calls were:\n" + _summary(calls)
+    )
+
+
+def test_interrupt_stops_the_client_too(interrupted_run):
+    """Covers an interrupt in the window before the container exists.
+
+    Tearing it down by name hits nothing then, and bash does not reap the backgrounded
+    client on exit — so the client would go on to create and run the container with
+    nobody watching. Stopping the client is what closes that window.
+    """
+    _, output, calls = interrupted_run()
+    assert "client-terminated" in calls, (
+        "the podman client was left running, so an interrupt before the container exists "
+        "would still start it; podman calls were:\n" + _summary(calls)
+    )


### PR DESCRIPTION
Ctrl-C did nothing — the run continued to completion however many times you pressed it, so aborting meant killing the container from another terminal. Three things swallowed the interrupt; the `-t` guess in the issue covers one of them.

**Why**

- Under `podman machine` (any macOS host) the CLI is a **remote client**, so the signal never entered the container.
- Natively `--sig-proxy` does deliver it, but to PID 1 — **tini**, which signals only its direct child: our `bash -c` wrapper. Non-interactive bash neither relays to its foreground child nor runs a trap until that child returns, and here that child is the whole e2e.
- This script had the same problem one level up: a trap does not run while a **foreground** command does.

**Changes**

- podman runs in the background with the script `wait`ing on it — bash *does* interrupt `wait` to run a trap — so the handler tears the run down itself. podman's exit code is still the script's; an interrupt exits 130.
- Both halves of the teardown matter. Removing the **container** stops the work — pytest, babs and the inner singularity job all live inside it. Stopping the **client** covers an interrupt before the container exists, which would otherwise create it and run unattended after we exit.
- The container is always named now, not only under `MECHABABS_E2E_KEEP`, and shares one id with the dev-campaign path.
- `tests/test_run_in_podman.py`: three tests that interrupt the real script against a stub `podman` (~2s, no image or container). The stub ignores SIGINT as the real client does, so a pass is not the stub dying on its own.

**Verified**

- Interrupted ~80s in, past `validating`: exits 130, container gone. Before, both kept running. Same before and after under native Linux podman in the podman-machine VM, since macOS podman is remote-only.
- Immediate Ctrl-C, before the container exists: 7/7 clean. Without the client-stop half, the orphan reached the end of bootstrap.
- The new tests fail on `main`, and with only the container half they fail exactly the client-stop test. Full uninterrupted run unchanged — its one failure is babs#394 chaining, same log signature as before.

Not `-t`: that fixes only the interactive case, not a redirected or CI run. Backgrounding does put the container's stdin on `/dev/null`, which nothing in the scenario reads. No `run_on_cluster.sh` change — it `exec`s, so the interrupt lands directly.

Fixes #105
