### PR TITLE
Study first campaign init

### DIFF
--- a/mechababs/campaign.py
+++ b/mechababs/campaign.py
@@ -188,7 +188,7 @@ def require_env_match(study, label):
     prefix = Path(sys.prefix).resolve()
     if prefix != venv:
         sys.exit(
-            f"not running in campaign {label!r}'s venv\n"
+            f"not running in the venv of campaign {label!r}\n"
             f"  expected: {venv}\n"
             f"  running:  {prefix}\n"
             f"Source the campaign's env.sh:\n"
@@ -202,7 +202,7 @@ def require_env_match(study, label):
     stamp = read_env_stamp(venv)
     if stamp is None or stamp.get("lock_sha256") != committed:
         sys.exit(
-            f"campaign {label!r}'s venv does not match its committed "
+            f"the venv of campaign {label!r} does not match its committed "
             f"{LOCK_FILENAME}\n"
             "The lock and the environment have drifted — either the lock was "
             "bumped and the venv not rebuilt, or the venv was built from a lock "

--- a/mechababs/campaign.py
+++ b/mechababs/campaign.py
@@ -1,0 +1,214 @@
+"""campaign.py — a campaign's layout inside a study, its selection, and its env guard.
+
+A campaign is a **config epoch**, not a dataset: one pinned environment, one bundle
+of BIDS-App configs, one cluster, and the state of this study's cells under it. It
+lives at ``<study>/.mechababs/campaigns/<label>/`` (docs/output_structure.md), and a
+study accumulates campaigns over time — a set of derivatives now, another a year
+later with newer tools, each its own ``<label>``.
+
+```
+<study>/.mechababs/campaigns/<label>/
+  campaign.yaml               the app bundle (ordered) + cluster choice + limit
+  bids-app-configs/           the app configs, copied in
+  clusters/                   the cluster config, copied in
+  env.sh                      source to select this campaign + activate its venv
+  pyproject.toml              declares mechababs + babs
+  uv.lock                     the resolved environment — the provenance record
+  sourcedata+derivatives.tsv  the statefile: this study's cells for this campaign
+  inclusions/                 the requested subject list per cell, pinned at scaffold
+  .venv/                      gitignored, rebuilt from the lock
+```
+
+Two rules this module enforces for every verb that comes later:
+
+**Selection is always the env var.** ``MECHABABS_CAMPAIGN`` names the label, and
+sourcing the campaign's ``env.sh`` is what sets it. There is no default-if-only-one
+shortcut and no ``--campaign`` flag, so one campaign and five behave identically.
+
+**The running venv must match the committed lock.** The lock is mutable through git
+history (that is how a mid-sweep version bump works), so "the venv I am running in"
+and "the environment this campaign records" can drift apart in either direction.
+``require_env_match`` refuses both directions rather than letting a run be recorded
+against tools that did not produce it.
+"""
+
+import hashlib
+import json
+import os
+import sys
+from pathlib import Path
+
+MECHABABS_DIR = ".mechababs"
+CAMPAIGNS_DIRNAME = "campaigns"
+
+CONFIG_FILENAME = "campaign.yaml"
+STATE_FILENAME = "sourcedata+derivatives.tsv"
+APPS_DIRNAME = "bids-app-configs"
+CLUSTERS_DIRNAME = "clusters"
+INCLUSIONS_DIRNAME = "inclusions"
+ENV_FILENAME = "env.sh"
+PYPROJECT_FILENAME = "pyproject.toml"
+LOCK_FILENAME = "uv.lock"
+VENV_DIRNAME = ".venv"
+
+# Written into the venv (so it is gitignored and per-environment by construction)
+# at build time, and read by the env-match guard. See `write_env_stamp`.
+STAMP_FILENAME = ".mechababs-env.json"
+
+CAMPAIGN_ENV_VAR = "MECHABABS_CAMPAIGN"
+
+# The statefile is TALL: one row per (source dataset x app config) cell.
+#   identity  — inputs, written at add-dataset, never overwritten
+#   topology  — derived from the app config
+#   derived   — reconciled each tick; state is READ OFF these, there is no status
+#               enum (`babs` empty -> scaffold; set + `merged` empty -> active;
+#               `merged` set -> done). Volatile job status stays in babs.
+IDENTITY_COLUMNS = ["source_dataset", "app_config", "processing_level",
+                    "n_subjects", "n_sessions"]
+TOPOLOGY_COLUMNS = ["depends_on"]
+DERIVED_COLUMNS = ["babs", "merged"]
+STATE_COLUMNS = IDENTITY_COLUMNS + TOPOLOGY_COLUMNS + DERIVED_COLUMNS
+
+
+def campaigns_dir(study):
+    return Path(study) / MECHABABS_DIR / CAMPAIGNS_DIRNAME
+
+
+def campaign_dir(study, label):
+    return campaigns_dir(study) / label
+
+
+def config_path(study, label):
+    return campaign_dir(study, label) / CONFIG_FILENAME
+
+
+def state_path(study, label):
+    return campaign_dir(study, label) / STATE_FILENAME
+
+
+def apps_dir(study, label):
+    return campaign_dir(study, label) / APPS_DIRNAME
+
+
+def clusters_dir(study, label):
+    return campaign_dir(study, label) / CLUSTERS_DIRNAME
+
+
+def inclusions_dir(study, label):
+    return campaign_dir(study, label) / INCLUSIONS_DIRNAME
+
+
+def env_path(study, label):
+    return campaign_dir(study, label) / ENV_FILENAME
+
+
+def pyproject_path(study, label):
+    return campaign_dir(study, label) / PYPROJECT_FILENAME
+
+
+def lock_path(study, label):
+    return campaign_dir(study, label) / LOCK_FILENAME
+
+
+def venv_path(study, label):
+    """The campaign's venv — one venv per campaign, beside the lock it was built from.
+
+    This is where ``uv sync --project <campaign-dir>`` puts it, which is what lets
+    ``env.sh`` be committed: the path is derivable from the campaign dir, not
+    recorded anywhere.
+    """
+    return campaign_dir(study, label) / VENV_DIRNAME
+
+
+def initial_header():
+    """The header line of a fresh statefile — no rows; add-dataset writes those."""
+    return "\t".join(STATE_COLUMNS) + "\n"
+
+
+def lock_digest(lock_text):
+    """The identity of a lock's *content* (what the env-match guard compares)."""
+    return hashlib.sha256(lock_text.encode()).hexdigest()
+
+
+def write_env_stamp(venv, label, lock_text):
+    """Record which lock the venv at ``venv`` was built from.
+
+    Lives inside the venv on purpose: the venv is gitignored and rebuilt, so the
+    stamp can never be committed, and it cannot outlive the environment it
+    describes. ``campaign update-env`` rewrites it when it rebuilds.
+    """
+    stamp = Path(venv) / STAMP_FILENAME
+    stamp.write_text(json.dumps(
+        {"label": label, "lock_sha256": lock_digest(lock_text)}, indent=2) + "\n")
+    return stamp
+
+
+def read_env_stamp(venv):
+    """The venv's stamp, or None if it has none (not built by mechababs)."""
+    stamp = Path(venv) / STAMP_FILENAME
+    if not stamp.is_file():
+        return None
+    try:
+        return json.loads(stamp.read_text())
+    except json.JSONDecodeError:
+        return None
+
+
+def selected_label():
+    """The campaign named by ``MECHABABS_CAMPAIGN``; exit if unset.
+
+    Selection is *always* explicit — no default-if-only-one — so the habit a user
+    forms on a one-campaign study is the one that still works on a five-campaign one.
+    """
+    label = os.environ.get(CAMPAIGN_ENV_VAR, "").strip()
+    if not label:
+        sys.exit(
+            f"no campaign selected ({CAMPAIGN_ENV_VAR} is unset).\n"
+            f"Source a campaign's env.sh to select it and activate its venv:\n"
+            f"  source {MECHABABS_DIR}/{CAMPAIGNS_DIRNAME}/<label>/{ENV_FILENAME}"
+        )
+    return label
+
+
+def require_env_match(study, label):
+    """Refuse unless this process is running the environment the campaign records.
+
+    Two failures, both of which would attribute a run to tools that did not produce
+    it: running from some *other* python (an ambient install, another campaign's
+    venv), and running from this campaign's venv after the committed lock moved
+    (or before a bumped lock was built). The fix for the second is
+    ``mechababs campaign update-env``, which the message names.
+    """
+    campaign = campaign_dir(study, label)
+    if not config_path(study, label).is_file():
+        sys.exit(f"no campaign {label!r} in this study (looked for "
+                 f"{config_path(study, label)})")
+
+    venv = venv_path(study, label).resolve()
+    prefix = Path(sys.prefix).resolve()
+    if prefix != venv:
+        sys.exit(
+            f"not running in campaign {label!r}'s venv\n"
+            f"  expected: {venv}\n"
+            f"  running:  {prefix}\n"
+            f"Source the campaign's env.sh:\n"
+            f"  source {env_path(study, label)}"
+        )
+
+    lock = lock_path(study, label)
+    if not lock.is_file():
+        sys.exit(f"campaign {label!r} has no {LOCK_FILENAME} ({lock})")
+    committed = lock_digest(lock.read_text())
+    stamp = read_env_stamp(venv)
+    if stamp is None or stamp.get("lock_sha256") != committed:
+        sys.exit(
+            f"campaign {label!r}'s venv does not match its committed "
+            f"{LOCK_FILENAME}\n"
+            "The lock and the environment have drifted — either the lock was "
+            "bumped and the venv not rebuilt, or the venv was built from a lock "
+            "that is no longer committed.\n"
+            f"Rebuild it:  mechababs campaign update-env\n"
+            f"  lock:  {lock}\n"
+            f"  venv:  {venv}"
+        )
+    return campaign

--- a/mechababs/campaign.py
+++ b/mechababs/campaign.py
@@ -38,6 +38,8 @@ import os
 import sys
 from pathlib import Path
 
+from mechababs import study as study_mod
+
 MECHABABS_DIR = ".mechababs"
 CAMPAIGNS_DIRNAME = "campaigns"
 
@@ -212,3 +214,18 @@ def require_env_match(study, label):
             f"  venv:  {venv}"
         )
     return campaign
+
+
+def require_selected_campaign(path="."):
+    """The three preconditions every *operating* verb shares, in one call.
+
+    In a study (``require_study_root``), with a campaign selected
+    (``selected_label``), running the environment that campaign records
+    (``require_env_match``). Returns ``(study, label, campaign_dir)``.
+
+    ``campaign init`` is the one command that does not take this: it runs before
+    the environment exists — it is what creates it.
+    """
+    study = study_mod.require_study_root(path)
+    label = selected_label()
+    return study, label, require_env_match(study, label)

--- a/mechababs/campaign.py
+++ b/mechababs/campaign.py
@@ -1,20 +1,25 @@
-"""campaign.py — a campaign's layout inside a study, its selection, and its env guard.
+"""campaign.py — a campaign's layout, its selection, and its env guard.
 
 A campaign is a **config epoch**, not a dataset: one pinned environment, one bundle
-of BIDS-App configs, one cluster, and the state of this study's cells under it. It
-lives at ``<study>/.mechababs/campaigns/<label>/`` (docs/output_structure.md), and a
-study accumulates campaigns over time — a set of derivatives now, another a year
+of BIDS-App configs, one cluster, and the state of that root's cells under it. It
+lives at ``<root>/.mechababs/campaigns/<label>/`` (docs/output_structure.md), and a
+root accumulates campaigns over time — a set of derivatives now, another a year
 later with newer tools, each its own ``<label>``.
 
+``root`` throughout this module is the **operating-level root**: the study or the
+superstudy the campaign is configured at, whose footprint is identical either way.
+``study`` is reserved for parameters that must be a lone or member study — only
+``state_path``, since a statefile exists only at a study.
+
 ```
-<study>/.mechababs/campaigns/<label>/
+<root>/.mechababs/campaigns/<label>/
   campaign.yaml               the app bundle (ordered) + cluster choice + limit
   bids-app-configs/           the app configs, copied in
   clusters/                   the cluster config, copied in
   env.sh                      source to select this campaign + activate its venv
   pyproject.toml              declares mechababs + babs
   uv.lock                     the resolved environment — the provenance record
-  sourcedata+derivatives.tsv  the statefile: this study's cells for this campaign
+  sourcedata+derivatives.tsv  the statefile: this study's cells (at a study only)
   inclusions/                 the requested subject list per cell, pinned at scaffold
   .venv/                      gitignored, rebuilt from the lock
 ```
@@ -72,54 +77,60 @@ DERIVED_COLUMNS = ["babs", "merged"]
 STATE_COLUMNS = IDENTITY_COLUMNS + TOPOLOGY_COLUMNS + DERIVED_COLUMNS
 
 
-def campaigns_dir(study):
-    return Path(study) / MECHABABS_DIR / CAMPAIGNS_DIRNAME
+def campaigns_dir(root):
+    return Path(root) / MECHABABS_DIR / CAMPAIGNS_DIRNAME
 
 
-def campaign_dir(study, label):
-    return campaigns_dir(study) / label
+def campaign_dir(root, label):
+    return campaigns_dir(root) / label
 
 
-def config_path(study, label):
-    return campaign_dir(study, label) / CONFIG_FILENAME
+def config_path(root, label):
+    return campaign_dir(root, label) / CONFIG_FILENAME
 
 
 def state_path(study, label):
+    """``study``, not ``root``: a statefile exists only at a study.
+
+    The one asymmetry in the campaign footprint. A superstudy's campaign dir carries
+    membership instead — per-cell state shards to the member studies, and the
+    superstudy computes its rollup from them.
+    """
     return campaign_dir(study, label) / STATE_FILENAME
 
 
-def apps_dir(study, label):
-    return campaign_dir(study, label) / APPS_DIRNAME
+def apps_dir(root, label):
+    return campaign_dir(root, label) / APPS_DIRNAME
 
 
-def clusters_dir(study, label):
-    return campaign_dir(study, label) / CLUSTERS_DIRNAME
+def clusters_dir(root, label):
+    return campaign_dir(root, label) / CLUSTERS_DIRNAME
 
 
-def inclusions_dir(study, label):
-    return campaign_dir(study, label) / INCLUSIONS_DIRNAME
+def inclusions_dir(root, label):
+    return campaign_dir(root, label) / INCLUSIONS_DIRNAME
 
 
-def env_path(study, label):
-    return campaign_dir(study, label) / ENV_FILENAME
+def env_path(root, label):
+    return campaign_dir(root, label) / ENV_FILENAME
 
 
-def pyproject_path(study, label):
-    return campaign_dir(study, label) / PYPROJECT_FILENAME
+def pyproject_path(root, label):
+    return campaign_dir(root, label) / PYPROJECT_FILENAME
 
 
-def lock_path(study, label):
-    return campaign_dir(study, label) / LOCK_FILENAME
+def lock_path(root, label):
+    return campaign_dir(root, label) / LOCK_FILENAME
 
 
-def venv_path(study, label):
+def venv_path(root, label):
     """The campaign's venv — one venv per campaign, beside the lock it was built from.
 
     This is where ``uv sync --project <campaign-dir>`` puts it, which is what lets
     ``env.sh`` be committed: the path is derivable from the campaign dir, not
     recorded anywhere.
     """
-    return campaign_dir(study, label) / VENV_DIRNAME
+    return campaign_dir(root, label) / VENV_DIRNAME
 
 
 def initial_header():
@@ -172,7 +183,7 @@ def selected_label():
     return label
 
 
-def require_env_match(study, label):
+def require_env_match(root, label):
     """Refuse unless this process is running the environment the campaign records.
 
     Two failures, both of which would attribute a run to tools that did not produce
@@ -181,12 +192,12 @@ def require_env_match(study, label):
     (or before a bumped lock was built). The fix for the second is
     ``mechababs campaign update-env``, which the message names.
     """
-    campaign = campaign_dir(study, label)
-    if not config_path(study, label).is_file():
-        sys.exit(f"no campaign {label!r} in this study (looked for "
-                 f"{config_path(study, label)})")
+    campaign = campaign_dir(root, label)
+    if not config_path(root, label).is_file():
+        sys.exit(f"no campaign {label!r} here (looked for "
+                 f"{config_path(root, label)})")
 
-    venv = venv_path(study, label).resolve()
+    venv = venv_path(root, label).resolve()
     prefix = Path(sys.prefix).resolve()
     if prefix != venv:
         sys.exit(
@@ -194,10 +205,10 @@ def require_env_match(study, label):
             f"  expected: {venv}\n"
             f"  running:  {prefix}\n"
             f"Source the campaign's env.sh:\n"
-            f"  source {env_path(study, label)}"
+            f"  source {env_path(root, label)}"
         )
 
-    lock = lock_path(study, label)
+    lock = lock_path(root, label)
     if not lock.is_file():
         sys.exit(f"campaign {label!r} has no {LOCK_FILENAME} ({lock})")
     committed = lock_digest(lock.read_text())
@@ -219,13 +230,13 @@ def require_env_match(study, label):
 def require_selected_campaign(path="."):
     """The three preconditions every *operating* verb shares, in one call.
 
-    In a study (``require_study_root``), with a campaign selected
+    At a study root (``require_study_root``), with a campaign selected
     (``selected_label``), running the environment that campaign records
-    (``require_env_match``). Returns ``(study, label, campaign_dir)``.
+    (``require_env_match``). Returns ``(root, label, campaign_dir)``.
 
     ``campaign init`` is the one command that does not take this: it runs before
     the environment exists — it is what creates it.
     """
-    study = study_mod.require_study_root(path)
+    root = study_mod.require_study_root(path)
     label = selected_label()
-    return study, label, require_env_match(study, label)
+    return root, label, require_env_match(root, label)

--- a/mechababs/campaign_init.py
+++ b/mechababs/campaign_init.py
@@ -34,6 +34,7 @@ import subprocess
 import sys
 import urllib.parse
 import urllib.request
+from contextlib import contextmanager
 from importlib import metadata
 from pathlib import Path
 
@@ -85,23 +86,62 @@ def describe_result(result):
     return str(message)
 
 
-def datalad_save(study, message, path):
-    """Commit the campaign's files to the study, path-scoped.
+class PendingSave:
+    """The save a ``campaign_save_scope`` block is working toward.
 
-    Straight into git, but that is the campaign's own ``.gitattributes`` doing it
-    (see ``GITATTRIBUTES``), not a flag on this save.
+    The block sets ``message``: a useful label names what the block did (the apps it
+    staged, the cell it advanced), which is not knowable at entry — and entry is
+    where the clean-in check has to happen.
+    """
+
+    def __init__(self):
+        self.message = None
+
+
+@contextmanager
+def campaign_save_scope(root, path):
+    """Clean in, one commit out: whatever the block writes at ``path``, committed.
+
+    **Clean in.** ``path`` must be clean *before* the block writes, so the commit is
+    attributable — everything in it is this block's work, and no pre-existing edit is
+    silently absorbed into a mechababs-authored commit. ``campaign init`` passes it
+    trivially (its target does not exist yet); the guard belongs here rather than at
+    the caller because the callers that follow — ``add-dataset`` saving the statefile,
+    scaffold pinning an inclusion — write into a directory a human may have touched.
+
+    The check is **path-scoped**, which is also what makes it cheap: a campaign dir
+    holds no subdatasets, so this is a status over a handful of small files rather
+    than a walk of the study's sourcedata.
+
+    Files land in git rather than annex, but that is the campaign's own
+    ``.gitattributes`` doing it (see ``GITATTRIBUTES``), not a flag on this save.
 
     Through ``datalad.api``, not a shelled-out ``datalad``: datalad is a declared
     dependency, so it is importable wherever this runs — including the ``uvx``
-    install, which has no ``bin/datalad`` on PATH to find. Same call the rest of
-    the codebase makes (``utils.datalad_save_scope``).
+    install, which has no ``bin/datalad`` beside the interpreter to find. (Sibling to
+    ``utils.datalad_save_scope``, whose clean-in is whole-dataset and whose save is
+    ``since=``-based; here the scope is one directory, so both can be path-scoped.)
     """
-    results = Dataset(str(study)).save(
-        path=str(path), message=message,
-        result_renderer="disabled", on_failure="ignore", return_type="list")
+    ds = Dataset(str(root))
+    dirty = ds.status(path=str(path), untracked="all", result_renderer="disabled",
+                      on_failure="ignore", return_type="list")
+    dirty = [r for r in dirty if r.get("state") != "clean"]
+    if dirty:
+        sys.exit(f"refusing to write into {path}: it is not clean, and the commit "
+                 f"would absorb changes mechababs did not make.\n" +
+                 "\n".join(f"  {r.get('state')}: {r.get('path')}" for r in dirty))
+
+    pending = PendingSave()
+    yield pending
+    if not pending.message:
+        raise RuntimeError(f"campaign_save_scope({path}) exited with no message set")
+
+    results = ds.save(path=str(path), message=pending.message,
+                      result_renderer="disabled", on_failure="ignore",
+                      return_type="list")
     failed = [r for r in results if r.get("status") not in ("ok", "notneeded")]
     if failed:
-        sys.exit(f"failed to commit the campaign into {study}\n" +
+        sys.exit(f"failed to commit {path} into {root}\n" +
                  "\n".join(f"  {r.get('status')}: {r.get('path')} "
                            f"({describe_result(r)})" for r in failed))
 
@@ -386,54 +426,58 @@ def init(study, label, app_args, cluster_arg, *, limit=None,
     if not app_args:
         sys.exit("--apps must name at least one BIDS-App config")
 
-    campaign.mkdir(parents=True)
+    # Everything that writes runs inside the scope: it checks the target is clean
+    # first, and commits what the block produced as one attributable node.
+    with campaign_save_scope(study, campaign) as save:
+        campaign.mkdir(parents=True)
 
-    # First file in, before anything it has to govern: git-annex reads the working
-    # tree's attributes as it adds, so the attribute must never be younger than a
-    # save that could reach these paths.
-    (campaign / ".gitattributes").write_text(GITATTRIBUTES)
+        # First file in, before anything it has to govern: git-annex reads the
+        # working tree's attributes as it adds, so the attribute must never be
+        # younger than a save that could reach these paths.
+        (campaign / ".gitattributes").write_text(GITATTRIBUTES)
 
-    # The venv is ephemeral and rebuilt from the lock. Ignore it from INSIDE the
-    # campaign dir, so mechababs' whole footprint stays under .mechababs/ and the
-    # study's own .gitignore is left alone.
-    (campaign / ".gitignore").write_text(f"{campaign_mod.VENV_DIRNAME}/\n")
+        # The venv is ephemeral and rebuilt from the lock. Ignore it from INSIDE the
+        # campaign dir, so mechababs' whole footprint stays under .mechababs/ and the
+        # study's own .gitignore is left alone.
+        (campaign / ".gitignore").write_text(f"{campaign_mod.VENV_DIRNAME}/\n")
 
-    apps = resolve_apps(campaign / campaign_mod.APPS_DIRNAME, app_args)
-    cluster_file = stage_config(
-        campaign / campaign_mod.CLUSTERS_DIRNAME, cluster_arg, "cluster")
+        apps = resolve_apps(campaign / campaign_mod.APPS_DIRNAME, app_args)
+        cluster_file = stage_config(
+            campaign / campaign_mod.CLUSTERS_DIRNAME, cluster_arg, "cluster")
 
-    config = {
-        "label": label,
-        "apps": [f"{campaign_mod.APPS_DIRNAME}/{filename}" for filename, _, _ in apps],
-        "cluster": f"{campaign_mod.CLUSTERS_DIRNAME}/{cluster_file}",
-        "limit": limit,
-    }
-    (campaign / campaign_mod.CONFIG_FILENAME).write_text(
-        yaml.safe_dump(config, sort_keys=False))
+        config = {
+            "label": label,
+            "apps": [f"{campaign_mod.APPS_DIRNAME}/{filename}"
+                     for filename, _, _ in apps],
+            "cluster": f"{campaign_mod.CLUSTERS_DIRNAME}/{cluster_file}",
+            "limit": limit,
+        }
+        (campaign / campaign_mod.CONFIG_FILENAME).write_text(
+            yaml.safe_dump(config, sort_keys=False))
 
-    # Header only: which source datasets a campaign acts on is an explicit
-    # selection, made by `add-dataset`, not implied by init.
-    (campaign / campaign_mod.STATE_FILENAME).write_text(campaign_mod.initial_header())
+        # Header only: which source datasets a campaign acts on is an explicit
+        # selection, made by `add-dataset`, not implied by init.
+        (campaign / campaign_mod.STATE_FILENAME).write_text(
+            campaign_mod.initial_header())
 
-    if mechababs_spec:
-        mechababs_req, mechababs_source = "mechababs", git_source(
-            *parse_source_spec(mechababs_spec, "mechababs"))
-    else:
-        mechababs_req, mechababs_source = running_mechababs_pin()
-    # No --babs: babs stays a plain dependency, so uv resolves the latest release
-    # from PyPI and freezes that version in the lock. A git ref is the override, for
-    # running a PR branch (or a local one) through a campaign.
-    babs_source = git_source(*parse_source_spec(babs_spec, "babs")) if babs_spec else None
-    (campaign / campaign_mod.PYPROJECT_FILENAME).write_text(
-        render_pyproject(label, mechababs_req, mechababs_source, babs_source))
+        if mechababs_spec:
+            mechababs_req, mechababs_source = "mechababs", git_source(
+                *parse_source_spec(mechababs_spec, "mechababs"))
+        else:
+            mechababs_req, mechababs_source = running_mechababs_pin()
+        # No --babs: babs stays a plain dependency, so uv resolves the latest release
+        # from PyPI and freezes that version in the lock. A git ref is the override,
+        # for running a PR branch (or a local one) through a campaign.
+        babs_source = (git_source(*parse_source_spec(babs_spec, "babs"))
+                       if babs_spec else None)
+        (campaign / campaign_mod.PYPROJECT_FILENAME).write_text(
+            render_pyproject(label, mechababs_req, mechababs_source, babs_source))
 
-    write_env_sh(campaign, label)
-    build_env(campaign, label)
+        write_env_sh(campaign, label)
+        build_env(campaign, label)
 
-    datalad_save(
-        study,
-        f"mechababs campaign init {label} "
-        f"(apps: {', '.join(name for _, name, _ in apps)}; cluster: {cluster_file})",
-        campaign,
-    )
+        save.message = (
+            f"mechababs campaign init {label} "
+            f"(apps: {', '.join(name for _, name, _ in apps)}; "
+            f"cluster: {cluster_file})")
     return campaign

--- a/mechababs/campaign_init.py
+++ b/mechababs/campaign_init.py
@@ -101,8 +101,7 @@ def git_source(url, ref):
     be run through a whole campaign before it is pushed anywhere (at the cost of a
     pin that resolves nowhere else — the accepted dev-mode trade).
     """
-    if url.startswith("git+"):
-        url = url[len("git+"):]
+    url = url.removeprefix("git+")
     local = Path(url)
     if local.exists():
         url = local.resolve().as_uri()
@@ -163,7 +162,7 @@ def stage_config(dest_dir, arg, what):
             sys.exit(f"{what} config URL has no filename: {arg}")
         dest = dest_dir / name
         print(f"+ fetch {arg} -> {dest}", file=sys.stderr)
-        with urllib.request.urlopen(arg) as response:          # noqa: S310 (http/https only)
+        with urllib.request.urlopen(arg) as response:      # http/https only, checked above
             dest.write_bytes(response.read())
         return name
     source = Path(arg)

--- a/mechababs/campaign_init.py
+++ b/mechababs/campaign_init.py
@@ -15,13 +15,16 @@ from a pinned ref::
 Everything after it runs from the venv this builds.
 
 **The lock is the provenance.** ``uv lock`` resolves ``mechababs`` and ``babs`` to
-exact commits and writes them into ``uv.lock``, which is committed to the study.
-That file — not a vendored code clone — is what says which tools ran, and a mid-campaign
-version bump is an edit to it, with its git history as the record of the campaign's
-config epochs. The mechababs pin is read from the running install (PEP 610
-``direct_url.json``), so the campaign records the mechababs the user actually
-invoked rather than a ref they would have to retype; babs, which mechababs only
-shells out to, is named by ``--babs URL@REF``.
+exact versions (a commit, for a git source) and writes them into ``uv.lock``, which
+is committed to the study. That file — not a vendored code clone — is what says which
+tools ran, and a mid-campaign version bump is an edit to it, with its git history as
+the record of the campaign's config epochs. The mechababs pin is read from the running
+install (PEP 610 ``direct_url.json``), so the campaign records the mechababs the user
+actually invoked rather than a ref they would have to retype; babs, which mechababs
+only shells out to, defaults to its latest **release** — declared as a plain
+dependency and frozen to an exact version by the lock — and ``--babs URL@REF`` pins a
+git checkout instead, which is how a PR branch (or a local one) gets run through a
+whole campaign.
 """
 
 import json
@@ -37,8 +40,6 @@ from pathlib import Path
 import yaml
 
 from mechababs import campaign as campaign_mod
-
-BABS_DEFAULT = "https://github.com/PennLINC/babs.git@main"
 
 # Runtime tools a campaign needs beyond mechababs + babs themselves — the same set
 # requirements-campaign.txt installs into a bootstrap-built venv. Kept as a literal
@@ -241,16 +242,23 @@ def _toml_inline(source):
     return "{ " + ", ".join(f"{k} = {json.dumps(v)}" for k, v in source.items()) + " }"
 
 
-def render_pyproject(label, mechababs_req, mechababs_source, babs_source):
+def render_pyproject(label, mechababs_req, mechababs_source, babs_source=None):
     """The campaign's dependency declaration — a uv *virtual* project.
 
     No ``[build-system]``: the campaign is not a package to build, it is a set of
     pinned dependencies for ``uv lock`` / ``uv sync`` to resolve and install.
+
+    A tool with no ``[tool.uv.sources]`` entry is a plain dependency, resolved from
+    PyPI and frozen to an exact released version by the lock — the default for both
+    babs and a registry-installed mechababs. A source entry overrides that with a
+    git (or path) checkout.
     """
     deps = [mechababs_req, "babs", *CAMPAIGN_EXTRAS]
-    sources = {"babs": babs_source}
+    sources = {}
     if mechababs_source:
         sources["mechababs"] = mechababs_source
+    if babs_source:
+        sources["babs"] = babs_source
 
     lines = [
         f"# The environment for mechababs campaign {label!r}.",
@@ -267,8 +275,10 @@ def render_pyproject(label, mechababs_req, mechababs_source, babs_source):
         "dependencies = [",
     ]
     lines += [f"    {_toml_str(d)}," for d in deps]
-    lines += ["]", "", "[tool.uv.sources]"]
-    lines += [f"{name} = {_toml_inline(source)}" for name, source in sources.items()]
+    lines += ["]"]
+    if sources:
+        lines += ["", "[tool.uv.sources]"]
+        lines += [f"{name} = {_toml_inline(source)}" for name, source in sources.items()]
     return "\n".join(lines) + "\n"
 
 
@@ -329,7 +339,7 @@ def write_env_sh(campaign, label):
 # --------------------------------------------------------------------------
 
 def init(study, label, app_args, cluster_arg, *, limit=None,
-         babs_spec=BABS_DEFAULT, mechababs_spec=None):
+         babs_spec=None, mechababs_spec=None):
     """Create campaign ``label`` in ``study``. Returns the campaign directory.
 
     Writes only under ``.mechababs/campaigns/<label>/`` — mechababs' change to a
@@ -375,7 +385,10 @@ def init(study, label, app_args, cluster_arg, *, limit=None,
             *parse_source_spec(mechababs_spec, "mechababs"))
     else:
         mechababs_req, mechababs_source = running_mechababs_pin()
-    babs_source = git_source(*parse_source_spec(babs_spec, "babs"))
+    # No --babs: babs stays a plain dependency, so uv resolves the latest release
+    # from PyPI and freezes that version in the lock. A git ref is the override, for
+    # running a PR branch (or a local one) through a campaign.
+    babs_source = git_source(*parse_source_spec(babs_spec, "babs")) if babs_spec else None
     (campaign / campaign_mod.PYPROJECT_FILENAME).write_text(
         render_pyproject(label, mechababs_req, mechababs_source, babs_source))
 

--- a/mechababs/campaign_init.py
+++ b/mechababs/campaign_init.py
@@ -54,6 +54,15 @@ CAMPAIGN_EXTRAS = [
 # A label names a directory and is exported as an env var, so keep it boring.
 LABEL_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 
+# Everything mechababs writes under a campaign dir is small text that a clone must
+# be able to read *without* fetching annex content — the lock above all, since
+# rebuilding the environment from a fresh clone is the whole reproduction story.
+# So the routing is declared once, as an attribute on the campaign dir, instead of
+# being asked for per save: it then holds for every later writer into the campaign,
+# and no save has to carry a `to_git` flag that would mis-route the moment its scope
+# reached a real subdataset.
+GITATTRIBUTES = "* annex.largefiles=nothing\n"
+
 DATALAD = str(Path(sys.prefix) / "bin" / "datalad")
 UV = "uv"
 
@@ -65,15 +74,13 @@ def run(*cmd, **kwargs):
 
 
 def datalad_save(study, message, path):
-    """Commit the campaign's files to the study, path-scoped, straight into git.
+    """Commit the campaign's files to the study, path-scoped.
 
-    ``--to-git``: every file here is small text that a clone must be able to read
-    without fetching annex content — the lock especially, since rebuilding the
-    environment from a fresh clone is the whole reproduction story.
+    Straight into git, but that is the campaign's own ``.gitattributes`` doing it
+    (see ``GITATTRIBUTES``), not a flag on this save.
     """
     datalad = DATALAD if Path(DATALAD).exists() else "datalad"
-    run(datalad, "save", "--dataset", str(study), "--message", message,
-        "--to-git", str(path))
+    run(datalad, "save", "--dataset", str(study), "--message", message, str(path))
 
 
 # --------------------------------------------------------------------------
@@ -357,6 +364,11 @@ def init(study, label, app_args, cluster_arg, *, limit=None,
         sys.exit("--apps must name at least one BIDS-App config")
 
     campaign.mkdir(parents=True)
+
+    # First file in, before anything it has to govern: git-annex reads the working
+    # tree's attributes as it adds, so the attribute must never be younger than a
+    # save that could reach these paths.
+    (campaign / ".gitattributes").write_text(GITATTRIBUTES)
 
     # The venv is ephemeral and rebuilt from the lock. Ignore it from INSIDE the
     # campaign dir, so mechababs' whole footprint stays under .mechababs/ and the

--- a/mechababs/campaign_init.py
+++ b/mechababs/campaign_init.py
@@ -122,8 +122,13 @@ def running_mechababs_pin():
     """
     try:
         dist = metadata.distribution("mechababs")
-    except metadata.PackageNotFoundError:      # running from a bare checkout
-        return "mechababs", None
+    except metadata.PackageNotFoundError:
+        # Running from a bare checkout (PYTHONPATH, no install): there is no
+        # install metadata to read, and an unsourced "mechababs" requirement
+        # would send uv to PyPI, where mechababs does not exist — a confusing
+        # resolver error far from the cause. Fail here, naming the fix.
+        sys.exit("cannot detect the running mechababs install (no distribution "
+                 "metadata) — pass --mechababs URL@REF to pin it explicitly")
     raw = dist.read_text("direct_url.json")
     if not raw:
         return f"mechababs=={dist.version}", None

--- a/mechababs/campaign_init.py
+++ b/mechababs/campaign_init.py
@@ -38,6 +38,7 @@ from importlib import metadata
 from pathlib import Path
 
 import yaml
+from datalad.api import Dataset
 
 from mechababs import campaign as campaign_mod
 
@@ -63,7 +64,6 @@ LABEL_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 # reached a real subdataset.
 GITATTRIBUTES = "* annex.largefiles=nothing\n"
 
-DATALAD = str(Path(sys.prefix) / "bin" / "datalad")
 UV = "uv"
 
 
@@ -73,14 +73,37 @@ def run(*cmd, **kwargs):
     subprocess.run([str(c) for c in cmd], check=True, **kwargs)
 
 
+def describe_result(result):
+    """A datalad result record's own explanation, in one line.
+
+    ``message`` is a plain string, a lazy ``(format, *args)`` tuple, or absent — so
+    a naive f-string prints a tuple at the user when it matters most.
+    """
+    message = result.get("message") or result.get("action", "no detail")
+    if isinstance(message, tuple):
+        message = message[0] % message[1:]
+    return str(message)
+
+
 def datalad_save(study, message, path):
     """Commit the campaign's files to the study, path-scoped.
 
     Straight into git, but that is the campaign's own ``.gitattributes`` doing it
     (see ``GITATTRIBUTES``), not a flag on this save.
+
+    Through ``datalad.api``, not a shelled-out ``datalad``: datalad is a declared
+    dependency, so it is importable wherever this runs — including the ``uvx``
+    install, which has no ``bin/datalad`` on PATH to find. Same call the rest of
+    the codebase makes (``utils.datalad_save_scope``).
     """
-    datalad = DATALAD if Path(DATALAD).exists() else "datalad"
-    run(datalad, "save", "--dataset", str(study), "--message", message, str(path))
+    results = Dataset(str(study)).save(
+        path=str(path), message=message,
+        result_renderer="disabled", on_failure="ignore", return_type="list")
+    failed = [r for r in results if r.get("status") not in ("ok", "notneeded")]
+    if failed:
+        sys.exit(f"failed to commit the campaign into {study}\n" +
+                 "\n".join(f"  {r.get('status')}: {r.get('path')} "
+                           f"({describe_result(r)})" for r in failed))
 
 
 # --------------------------------------------------------------------------

--- a/mechababs/campaign_init.py
+++ b/mechababs/campaign_init.py
@@ -1,0 +1,387 @@
+"""campaign_init.py — the body of ``mechababs campaign init``.
+
+Creates a campaign inside an existing study: copies the user's app + cluster
+configs in, declares and resolves the environment that will run them, builds that
+environment, and writes the empty statefile the reconciler fills.
+
+This is the one command that runs *before* the campaign environment exists, so it
+is the one command that may run from anywhere — typically ephemerally, straight
+from a pinned ref::
+
+    uvx --from git+https://github.com/con/mechababs@v0.2 \\
+        mechababs campaign init nprep --apps mriqc.yaml,fmriprep-anat.yaml \\
+                                      --cluster dartmouth.yaml
+
+Everything after it runs from the venv this builds.
+
+**The lock is the provenance.** ``uv lock`` resolves ``mechababs`` and ``babs`` to
+exact commits and writes them into ``uv.lock``, which is committed to the study.
+That file — not a vendored code clone — is what says which tools ran, and a mid-campaign
+version bump is an edit to it, with its git history as the record of the campaign's
+config epochs. The mechababs pin is read from the running install (PEP 610
+``direct_url.json``), so the campaign records the mechababs the user actually
+invoked rather than a ref they would have to retype; babs, which mechababs only
+shells out to, is named by ``--babs URL@REF``.
+"""
+
+import json
+import re
+import shutil
+import subprocess
+import sys
+import urllib.parse
+import urllib.request
+from importlib import metadata
+from pathlib import Path
+
+import yaml
+
+from mechababs import campaign as campaign_mod
+
+BABS_DEFAULT = "https://github.com/PennLINC/babs.git@main"
+
+# Runtime tools a campaign needs beyond mechababs + babs themselves — the same set
+# requirements-campaign.txt installs into a bootstrap-built venv. Kept as a literal
+# because this command may run from an ephemeral uvx install, which has the
+# mechababs *package* but not the repo file.
+CAMPAIGN_EXTRAS = [
+    "con-duct",     # usage/resource logs alongside every run
+    "visidata",     # interactive TSV viewer for the statefile
+    "pytest",       # runs the packaged e2e scenario behind `mechababs test-cluster`
+]
+
+# A label names a directory and is exported as an env var, so keep it boring.
+LABEL_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+DATALAD = str(Path(sys.prefix) / "bin" / "datalad")
+UV = "uv"
+
+
+def run(*cmd, **kwargs):
+    """Run a command, echoing it; abort on non-zero exit."""
+    print("+ " + " ".join(str(c) for c in cmd), file=sys.stderr)
+    subprocess.run([str(c) for c in cmd], check=True, **kwargs)
+
+
+def datalad_save(study, message, path):
+    """Commit the campaign's files to the study, path-scoped, straight into git.
+
+    ``--to-git``: every file here is small text that a clone must be able to read
+    without fetching annex content — the lock especially, since rebuilding the
+    environment from a fresh clone is the whole reproduction story.
+    """
+    datalad = DATALAD if Path(DATALAD).exists() else "datalad"
+    run(datalad, "save", "--dataset", str(study), "--message", message,
+        "--to-git", str(path))
+
+
+# --------------------------------------------------------------------------
+# Pinning the tools
+# --------------------------------------------------------------------------
+
+def parse_source_spec(spec, what):
+    """Split a ``URL@REF`` pin. ``URL`` is anything git clones, a local path included.
+
+    The ``URL@REF`` shape (and the requirement that ``REF`` be given rather than
+    defaulted) is carried over from ``bootstrap.sh``: naming the ref explicitly is
+    what makes "run a campaign against this PR branch" a config change instead of a
+    code change.
+    """
+    url, sep, ref = spec.rpartition("@")
+    if not sep or not url or not ref:
+        sys.exit(f"--{what} expects URL@REF (e.g. "
+                 f"https://github.com/PennLINC/babs.git@main), got: {spec}")
+    return url, ref
+
+
+def git_source(url, ref):
+    """A ``[tool.uv.sources]`` entry for a git checkout at ``ref``.
+
+    A local path becomes a ``file://`` URL, so a branch that exists only on disk can
+    be run through a whole campaign before it is pushed anywhere (at the cost of a
+    pin that resolves nowhere else — the accepted dev-mode trade).
+    """
+    if url.startswith("git+"):
+        url = url[len("git+"):]
+    local = Path(url)
+    if local.exists():
+        url = local.resolve().as_uri()
+    return {"git": url, "rev": ref}
+
+
+def running_mechababs_pin():
+    """How to pin the mechababs that is running: ``(requirement, source_or_None)``.
+
+    Read from PEP 610 ``direct_url.json``, which uv and pip write for every
+    non-registry install:
+
+    - installed from git (the ``uvx --from git+…`` case) -> pinned by the **resolved
+      commit**, not the branch name, so the campaign records exactly what ran;
+    - installed from a local dir (a dev checkout) -> pinned by path, editable
+      preserved. Honest rather than reproducible elsewhere — dev mode's known cost;
+    - installed from a registry (a future PyPI release) -> a plain ``==`` version.
+    """
+    try:
+        dist = metadata.distribution("mechababs")
+    except metadata.PackageNotFoundError:      # running from a bare checkout
+        return "mechababs", None
+    raw = dist.read_text("direct_url.json")
+    if not raw:
+        return f"mechababs=={dist.version}", None
+    direct = json.loads(raw)
+    url = direct.get("url", "")
+    if "vcs_info" in direct:
+        vcs = direct["vcs_info"]
+        return "mechababs", {"git": url, "rev": vcs.get("commit_id")
+                             or vcs.get("requested_revision")}
+    if "dir_info" in direct:
+        path = Path(urllib.parse.unquote(urllib.parse.urlparse(url).path))
+        source = {"path": str(path)}
+        if direct["dir_info"].get("editable"):
+            source["editable"] = True
+        return "mechababs", source
+    return "mechababs", {"url": url}          # a wheel/sdist by URL
+
+
+# --------------------------------------------------------------------------
+# Staging the user's configs
+# --------------------------------------------------------------------------
+
+def stage_config(dest_dir, arg, what):
+    """Copy one config into the campaign; return its filename.
+
+    App and cluster configs are **user-provided**, given by path or URL and copied
+    in — never a bare name resolved against a directory mechababs knows about. The
+    copy is the point: the config that produced a run is committed in the study, so
+    the run reproduces from the study alone.
+    """
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    parsed = urllib.parse.urlparse(arg)
+    if parsed.scheme in ("http", "https"):
+        name = Path(parsed.path).name
+        if not name:
+            sys.exit(f"{what} config URL has no filename: {arg}")
+        dest = dest_dir / name
+        print(f"+ fetch {arg} -> {dest}", file=sys.stderr)
+        with urllib.request.urlopen(arg) as response:          # noqa: S310 (http/https only)
+            dest.write_bytes(response.read())
+        return name
+    source = Path(arg)
+    if not source.is_file():
+        sys.exit(f"{what} config not found: {arg}\n"
+                 f"App and cluster configs are given by path or URL — mechababs "
+                 f"ships examples/ as starters to copy, not a library to name.")
+    dest = dest_dir / source.name
+    shutil.copy(source, dest)
+    return source.name
+
+
+def app_name(filename):
+    """An app config's identity: its filename stem (``fMRIPrep-25.2.5+anat``).
+
+    The same identity the derivative directory and the statefile's ``app_config``
+    column carry. No declared key — the filename IS the name.
+    """
+    return Path(filename).stem
+
+
+def declared_depends_on(config_path):
+    """The app config's ``mechababs.depends_on``, or ``""``.
+
+    mechababs-owned and deliberately separate from babs's ``input_datasets``:
+    orchestration topology is mechababs's, run-wiring is babs's, and a gate-type
+    dependency (mriqc gating fmriprep) is never an input at all.
+    """
+    config = yaml.safe_load(Path(config_path).read_text()) or {}
+    return ((config.get("mechababs") or {}).get("depends_on") or "")
+
+
+def resolve_apps(dest_dir, app_args):
+    """Stage the app bundle; return ordered ``[(filename, name, depends_on), …]``.
+
+    Duplicate names are rejected **before** anything is copied, so a rejected bundle
+    never half-populates the campaign. A ``depends_on`` naming an app outside this
+    bundle is rejected too: the edge could never resolve, and catching it here beats
+    surfacing it once per dataset at ``add-dataset``.
+    """
+    names = [app_name(Path(urllib.parse.urlparse(a).path or a).name) for a in app_args]
+    duplicates = {n for n in names if names.count(n) > 1}
+    if duplicates:
+        sys.exit(f"duplicate app config(s): {', '.join(sorted(duplicates))} — "
+                 f"each app in a campaign needs a distinct name (the filename stem)")
+
+    apps = []
+    for arg in app_args:
+        filename = stage_config(dest_dir, arg, "app")
+        name = app_name(filename)
+        apps.append((filename, name, declared_depends_on(dest_dir / filename)))
+
+    known = {name for _, name, _ in apps}
+    for _, name, upstream in apps:
+        if upstream and upstream not in known:
+            sys.exit(f"app {name!r} declares depends_on: {upstream!r}, which is not "
+                     f"in this campaign ({', '.join(sorted(known))})")
+    return apps
+
+
+# --------------------------------------------------------------------------
+# The campaign environment
+# --------------------------------------------------------------------------
+
+def _toml_str(value):
+    return json.dumps(str(value))       # TOML basic strings are JSON-compatible here
+
+
+def _toml_inline(source):
+    # json.dumps renders both the strings and the `editable = true` bool as TOML.
+    return "{ " + ", ".join(f"{k} = {json.dumps(v)}" for k, v in source.items()) + " }"
+
+
+def render_pyproject(label, mechababs_req, mechababs_source, babs_source):
+    """The campaign's dependency declaration — a uv *virtual* project.
+
+    No ``[build-system]``: the campaign is not a package to build, it is a set of
+    pinned dependencies for ``uv lock`` / ``uv sync`` to resolve and install.
+    """
+    deps = [mechababs_req, "babs", *CAMPAIGN_EXTRAS]
+    sources = {"babs": babs_source}
+    if mechababs_source:
+        sources["mechababs"] = mechababs_source
+
+    lines = [
+        f"# The environment for mechababs campaign {label!r}.",
+        "#",
+        "# Generated by `mechababs campaign init`, then resolved into uv.lock — the",
+        "# lock is the campaign's provenance record of which mechababs + babs ran.",
+        "# Edit and re-lock (`mechababs campaign update-env`) to bump mid-campaign:",
+        "# completed cells keep the lock that produced them, new ones run at the new one.",
+        "",
+        "[project]",
+        f"name = {_toml_str('mechababs-campaign-' + label)}",
+        'version = "0"',
+        'requires-python = ">=3.10"',
+        "dependencies = [",
+    ]
+    lines += [f"    {_toml_str(d)}," for d in deps]
+    lines += ["]", "", "[tool.uv.sources]"]
+    lines += [f"{name} = {_toml_inline(source)}" for name, source in sources.items()]
+    return "\n".join(lines) + "\n"
+
+
+def build_env(campaign, label):
+    """Resolve the campaign's lock and build its venv from it; stamp the venv.
+
+    ``uv lock`` pins every dependency (the git refs to commits) and ``uv sync``
+    installs exactly that — so the environment and the committed lock agree by
+    construction, which is what the env-match guard later checks.
+    """
+    run(UV, "lock", "--project", str(campaign))
+    run(UV, "sync", "--project", str(campaign), "--frozen")
+    venv = campaign / campaign_mod.VENV_DIRNAME
+    campaign_mod.write_env_stamp(
+        venv, label, (campaign / campaign_mod.LOCK_FILENAME).read_text())
+    return venv
+
+
+ENV_SH_TEMPLATE = """\
+# mechababs campaign {label!r} — SOURCE this file, don't execute it:
+#
+#     source {rel}
+#
+# It does the two things every mechababs command needs, together so they cannot
+# disagree: selects this campaign (there is one venv per campaign, and selection is
+# always explicit — no default-if-only-one) and activates the venv its uv.lock
+# built. `deactivate` leaves the venv; MECHABABS_CAMPAIGN stays set until you unset it.
+#
+# Committed on purpose: the venv path is derived from this file's own location, so
+# nothing here is specific to one machine.
+if [ -n "${{BASH_SOURCE:-}}" ]; then
+    _mechababs_self="${{BASH_SOURCE}}"
+else
+    _mechababs_self="$0"                      # zsh, dash: $0 is the sourced file
+fi
+_mechababs_campaign="$(cd "$(dirname "$_mechababs_self")" && pwd)"
+
+export MECHABABS_CAMPAIGN={label_sh}
+. "$_mechababs_campaign/{venv}/bin/activate"
+
+unset _mechababs_self _mechababs_campaign
+"""
+
+
+def write_env_sh(campaign, label):
+    """The one-step select-and-activate script (committed; see the template)."""
+    path = campaign / campaign_mod.ENV_FILENAME
+    path.write_text(ENV_SH_TEMPLATE.format(
+        label=label,
+        label_sh=f"'{label}'",
+        rel=f"{campaign_mod.MECHABABS_DIR}/{campaign_mod.CAMPAIGNS_DIRNAME}/"
+            f"{label}/{campaign_mod.ENV_FILENAME}",
+        venv=campaign_mod.VENV_DIRNAME,
+    ))
+    return path
+
+
+# --------------------------------------------------------------------------
+
+def init(study, label, app_args, cluster_arg, *, limit=None,
+         babs_spec=BABS_DEFAULT, mechababs_spec=None):
+    """Create campaign ``label`` in ``study``. Returns the campaign directory.
+
+    Writes only under ``.mechababs/campaigns/<label>/`` — mechababs' change to a
+    study is additive, and never touches what upstream authored.
+    """
+    if not LABEL_RE.match(label):
+        sys.exit(f"invalid campaign label {label!r} — it names a directory and is "
+                 f"exported as an env var; use letters, digits, '.', '_', '-'")
+    campaign = campaign_mod.campaign_dir(study, label)
+    if campaign.exists():
+        sys.exit(f"campaign {label!r} already exists: {campaign}\n"
+                 f"A campaign is a config epoch — start another one under a new "
+                 f"label rather than editing this one's identity.")
+    if not app_args:
+        sys.exit("--apps must name at least one BIDS-App config")
+
+    campaign.mkdir(parents=True)
+
+    # The venv is ephemeral and rebuilt from the lock. Ignore it from INSIDE the
+    # campaign dir, so mechababs' whole footprint stays under .mechababs/ and the
+    # study's own .gitignore is left alone.
+    (campaign / ".gitignore").write_text(f"{campaign_mod.VENV_DIRNAME}/\n")
+
+    apps = resolve_apps(campaign / campaign_mod.APPS_DIRNAME, app_args)
+    cluster_file = stage_config(
+        campaign / campaign_mod.CLUSTERS_DIRNAME, cluster_arg, "cluster")
+
+    config = {
+        "label": label,
+        "apps": [f"{campaign_mod.APPS_DIRNAME}/{filename}" for filename, _, _ in apps],
+        "cluster": f"{campaign_mod.CLUSTERS_DIRNAME}/{cluster_file}",
+        "limit": limit,
+    }
+    (campaign / campaign_mod.CONFIG_FILENAME).write_text(
+        yaml.safe_dump(config, sort_keys=False))
+
+    # Header only: which source datasets a campaign acts on is an explicit
+    # selection, made by `add-dataset`, not implied by init.
+    (campaign / campaign_mod.STATE_FILENAME).write_text(campaign_mod.initial_header())
+
+    if mechababs_spec:
+        mechababs_req, mechababs_source = "mechababs", git_source(
+            *parse_source_spec(mechababs_spec, "mechababs"))
+    else:
+        mechababs_req, mechababs_source = running_mechababs_pin()
+    babs_source = git_source(*parse_source_spec(babs_spec, "babs"))
+    (campaign / campaign_mod.PYPROJECT_FILENAME).write_text(
+        render_pyproject(label, mechababs_req, mechababs_source, babs_source))
+
+    write_env_sh(campaign, label)
+    build_env(campaign, label)
+
+    datalad_save(
+        study,
+        f"mechababs campaign init {label} "
+        f"(apps: {', '.join(name for _, name, _ in apps)}; cluster: {cluster_file})",
+        campaign,
+    )
+    return campaign

--- a/mechababs/cli.py
+++ b/mechababs/cli.py
@@ -13,6 +13,8 @@ import sys
 from pathlib import Path
 
 from mechababs import __version__
+from mechababs import campaign as campaign_mod
+from mechababs import campaign_init
 from mechababs import construct
 from mechababs import guard
 from mechababs import iterate as iterate_mod
@@ -20,6 +22,7 @@ from mechababs import retire as retire_mod
 from mechababs import select
 from mechababs import state
 from mechababs import status as status_mod
+from mechababs import study as study_mod
 from mechababs import utils
 from mechababs import validate as validate_mod
 
@@ -62,6 +65,34 @@ def _require_campaign_venv(campaign):
         sys.exit(f"must run from the campaign venv ({venv}), but sys.prefix is {prefix}\n"
                  f"invoke as: {venv}/bin/mechababs …")
     return venv
+
+
+def cmd_campaign_init(args):
+    """Create a campaign in the study you are standing in.
+
+    The one command that runs before a campaign environment exists — so it is the
+    one that may run from anywhere (typically ``uvx --from git+…``), and the one
+    that does not take the env-match guard. It creates the environment the guard
+    will check from here on.
+
+    The study is the current directory, not a flag: study-first commands operate on
+    where you are, and this one has no ledger or config to point elsewhere with.
+    """
+    study = study_mod.require_study_root(".")
+    # `--apps a.yaml,b.yaml` (as the quickstart shows) and a repeated `--apps` both
+    # work, and compose — the bundle is ordered as written either way.
+    apps = [app.strip() for group in args.apps for app in group.split(",") if app.strip()]
+    campaign = campaign_init.init(
+        study, args.label, apps, args.cluster, limit=args.limit,
+        babs_spec=args.babs, mechababs_spec=args.mechababs,
+    )
+    rel = campaign.relative_to(study)
+    print(f"\ncampaign {args.label!r} created at {rel}", file=sys.stderr)
+    print("Next, select it and activate its environment, then add data:",
+          file=sys.stderr)
+    print(f"  source {rel}/{campaign_mod.ENV_FILENAME}", file=sys.stderr)
+    print("  mechababs add-dataset --sourcedata sourcedata/<id>", file=sys.stderr)
+    return 0
 
 
 def cmd_configure(args):
@@ -242,6 +273,41 @@ def main():
     )
     p.add_argument("--version", action="version", version=f"mechababs {__version__}")
     sub = p.add_subparsers(dest="cmd", required=True)
+
+    pcamp = sub.add_parser(
+        "campaign", help="create a campaign in this study, or rebuild its environment")
+    camp_sub = pcamp.add_subparsers(dest="campaign_cmd", required=True)
+    pci = camp_sub.add_parser(
+        "init",
+        help="create a campaign in the study you are standing in",
+        description=(
+            "Create a campaign — one config epoch — inside an existing study: copy "
+            "your app + cluster configs into .mechababs/campaigns/<label>/, pin "
+            "mechababs + babs into a uv.lock, build the campaign's venv from that "
+            "lock, and write the empty statefile. Which source datasets the campaign "
+            "acts on is a separate, explicit step (`add-dataset`). This is the one "
+            "command that runs before the campaign environment exists, so it can be "
+            "run ephemerally: `uvx --from git+https://github.com/con/mechababs@<ref> "
+            "mechababs campaign init …`."
+        ),
+    )
+    pci.add_argument("label", help="the campaign's identity (its directory name, and "
+                                   "what MECHABABS_CAMPAIGN selects)")
+    pci.add_argument("--apps", action="append", required=True, metavar="PATH|URL[,…]",
+                     help="BIDS-App configs, ordered: paths or URLs, copied into the "
+                          "campaign. Comma-separated, and repeatable.")
+    pci.add_argument("--cluster", required=True, metavar="PATH|URL",
+                     help="cluster config: a path or URL, copied into the campaign")
+    pci.add_argument("--limit", type=int, default=None,
+                     help="cap each source dataset's inclusion to the first N eligible "
+                          "subjects (default: all)")
+    pci.add_argument("--babs", default=campaign_init.BABS_DEFAULT, metavar="URL@REF",
+                     help=f"the babs to pin (default: {campaign_init.BABS_DEFAULT}). "
+                          f"URL is anything git clones, a local checkout included.")
+    pci.add_argument("--mechababs", default=None, metavar="URL@REF",
+                     help="the mechababs to pin (default: whichever mechababs is "
+                          "running this command, pinned by its resolved commit)")
+    pci.set_defaults(func=cmd_campaign_init)
 
     pc = sub.add_parser("configure",
                         help="bind an ordered pipeline-set to a cluster (run from the campaign venv)")

--- a/mechababs/cli.py
+++ b/mechababs/cli.py
@@ -301,9 +301,11 @@ def main():
     pci.add_argument("--limit", type=int, default=None,
                      help="cap each source dataset's inclusion to the first N eligible "
                           "subjects (default: all)")
-    pci.add_argument("--babs", default=campaign_init.BABS_DEFAULT, metavar="URL@REF",
-                     help=f"the babs to pin (default: {campaign_init.BABS_DEFAULT}). "
-                          f"URL is anything git clones, a local checkout included.")
+    pci.add_argument("--babs", default=None, metavar="URL@REF",
+                     help="pin babs to a git checkout instead of the default, which is "
+                          "the latest babs release from PyPI, frozen to an exact version "
+                          "by the lock. URL is anything git clones, a local checkout "
+                          "included — which is how a PR branch gets run through a campaign.")
     pci.add_argument("--mechababs", default=None, metavar="URL@REF",
                      help="the mechababs to pin (default: whichever mechababs is "
                           "running this command, pinned by its resolved commit)")

--- a/mechababs/study.py
+++ b/mechababs/study.py
@@ -1,0 +1,39 @@
+"""study.py — the study a mechababs command operates in.
+
+Study-first: mechababs operates on a BIDS study that **already exists** on disk —
+cloned, or authored by another tool — and never creates one (docs/spec.md,
+"Layout & input"). Every command therefore begins by answering the same question,
+so it is answered in exactly one place here.
+
+The check is deliberately shallow: a study root is a datalad dataset (or, for a
+fixture, a plain git repo). It is not "does this look like valid BIDS" — the
+commands that need real study content (``add-dataset`` reading the per-subject
+metadata TSV, scaffold reading ``sourcedata/``) fail on the thing they actually
+need, with a message about that thing. What this module protects against is the
+much commoner mistake of running from the wrong directory entirely.
+"""
+
+import sys
+from pathlib import Path
+
+
+def is_study_root(path):
+    """True if ``path`` is a dataset root: datalad, or plain git for a fixture.
+
+    ``.git`` is tested with ``exists()`` rather than ``is_dir()`` so a git
+    worktree (whose ``.git`` is a file) counts.
+    """
+    path = Path(path)
+    return (path / ".datalad").is_dir() or (path / ".git").exists()
+
+
+def require_study_root(path="."):
+    """Resolve ``path`` and exit unless it is a study root."""
+    study = Path(path).resolve()
+    if not is_study_root(study):
+        sys.exit(
+            f"not a study (no datalad/git dataset here): {study}\n"
+            "mechababs operates inside an existing BIDS study — cd into one, or "
+            "clone one first (mechababs does not create studies)."
+        )
+    return study

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,11 @@ description = "Automation glue for running BIDS apps across many datasets on HPC
 requires-python = ">=3.10"
 dependencies = [
     "pyyaml",
+    # >=1.6 is a floor, not a preference: mechababs' change-making transitions are
+    # `datalad run`-captured, and the wrapped command commits its own work (babs
+    # init and friends). Released datalad 1.4 silently drops the run record in that
+    # case; 1.6 added the cmd_made_commits / dirty-committed machinery that keeps it
+    # (and lets `datalad.run.dirty-committed=error` stay armed).
     "datalad>=1.6",
     "datalad-container",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,11 @@ mechababs = "mechababs.cli:main"
 # where the packaged e2e conftest registers --cluster-config a second time and
 # collection fails outright.
 testpaths = ["tests"]
+# The unit suite must run with no cluster, no container, and no network. The one
+# test that really resolves a campaign environment needs `uv` and the network, so
+# it is marked and deselected by default; run it with `pytest -m uv_build`.
+markers = ["uv_build: really runs `uv lock` + `uv sync` (needs uv and the network)"]
+addopts = "-m 'not uv_build'"
 # Live phase markers during the long steps (venv build, babs init, later job
 # deploys) so a run isn't a silent wait. Add `-s` on top to stream the raw
 # subprocess output (the pip build, babs submit, ...) when you need to dig in.

--- a/tests/test_campaign.py
+++ b/tests/test_campaign.py
@@ -91,8 +91,8 @@ def test_require_selected_campaign_bundles_the_three_preconditions(tmp_path, mon
     make_campaign(tmp_path)
     monkeypatch.setenv(campaign_mod.CAMPAIGN_ENV_VAR, "nprep")
     pretend_running_in(monkeypatch, campaign_mod.venv_path(tmp_path, "nprep"))
-    study, label, campaign = campaign_mod.require_selected_campaign(tmp_path)
-    assert (study, label, campaign) == (
+    root, label, campaign = campaign_mod.require_selected_campaign(tmp_path)
+    assert (root, label, campaign) == (
         tmp_path.resolve(), "nprep", campaign_mod.campaign_dir(tmp_path, "nprep"))
 
 

--- a/tests/test_campaign.py
+++ b/tests/test_campaign.py
@@ -1,0 +1,86 @@
+"""Unit tests for campaign selection and the env-match guard.
+
+The guard is what keeps a run from being recorded against tools that did not
+produce it, so both drift directions (wrong venv entirely; right venv, moved lock)
+are tested explicitly.
+"""
+
+import sys
+
+import pytest
+
+from mechababs import campaign as campaign_mod
+
+
+def make_campaign(tmp_path, label="nprep", lock_text="lock-v1\n", *, stamp=True):
+    """A campaign dir complete enough for the guard: config, lock, venv (+stamp)."""
+    cdir = campaign_mod.campaign_dir(tmp_path, label)
+    cdir.mkdir(parents=True)
+    campaign_mod.config_path(tmp_path, label).write_text("label: nprep\n")
+    campaign_mod.lock_path(tmp_path, label).write_text(lock_text)
+    venv = campaign_mod.venv_path(tmp_path, label)
+    venv.mkdir()
+    if stamp:
+        campaign_mod.write_env_stamp(venv, label, lock_text)
+    return cdir
+
+
+def pretend_running_in(monkeypatch, venv):
+    monkeypatch.setattr(sys, "prefix", str(venv))
+
+
+def test_statefile_header_is_the_tall_cell_schema():
+    assert campaign_mod.initial_header() == (
+        "source_dataset\tapp_config\tprocessing_level\tn_subjects\tn_sessions\t"
+        "depends_on\tbabs\tmerged\n"
+    )
+
+
+def test_selected_label_reads_the_env_var(monkeypatch):
+    monkeypatch.setenv(campaign_mod.CAMPAIGN_ENV_VAR, "nprep")
+    assert campaign_mod.selected_label() == "nprep"
+
+
+def test_selected_label_exits_when_unset(monkeypatch):
+    # no default-if-only-one: selection is always explicit
+    monkeypatch.delenv(campaign_mod.CAMPAIGN_ENV_VAR, raising=False)
+    with pytest.raises(SystemExit):
+        campaign_mod.selected_label()
+
+
+def test_env_match_passes_for_a_venv_built_from_the_committed_lock(tmp_path, monkeypatch):
+    make_campaign(tmp_path)
+    pretend_running_in(monkeypatch, campaign_mod.venv_path(tmp_path, "nprep"))
+    assert campaign_mod.require_env_match(tmp_path, "nprep") == \
+        campaign_mod.campaign_dir(tmp_path, "nprep")
+
+
+def test_env_match_refuses_an_unknown_campaign(tmp_path):
+    with pytest.raises(SystemExit):
+        campaign_mod.require_env_match(tmp_path, "nope")
+
+
+def test_env_match_refuses_another_python(tmp_path, monkeypatch):
+    make_campaign(tmp_path)
+    # an ambient install, or another campaign's venv
+    pretend_running_in(monkeypatch, tmp_path / "elsewhere")
+    with pytest.raises(SystemExit) as e:
+        campaign_mod.require_env_match(tmp_path, "nprep")
+    assert "env.sh" in str(e.value)
+
+
+def test_env_match_refuses_a_venv_that_predates_a_bumped_lock(tmp_path, monkeypatch):
+    make_campaign(tmp_path, lock_text="lock-v1\n")
+    # the lock was bumped (mid-sweep version bump) and the venv not rebuilt
+    campaign_mod.lock_path(tmp_path, "nprep").write_text("lock-v2\n")
+    pretend_running_in(monkeypatch, campaign_mod.venv_path(tmp_path, "nprep"))
+    with pytest.raises(SystemExit) as e:
+        campaign_mod.require_env_match(tmp_path, "nprep")
+    assert "campaign update-env" in str(e.value)
+
+
+def test_env_match_refuses_a_venv_mechababs_did_not_build(tmp_path, monkeypatch):
+    make_campaign(tmp_path, stamp=False)
+    pretend_running_in(monkeypatch, campaign_mod.venv_path(tmp_path, "nprep"))
+    with pytest.raises(SystemExit):
+        campaign_mod.require_env_match(tmp_path, "nprep")

--- a/tests/test_campaign.py
+++ b/tests/test_campaign.py
@@ -84,3 +84,20 @@ def test_env_match_refuses_a_venv_mechababs_did_not_build(tmp_path, monkeypatch)
     pretend_running_in(monkeypatch, campaign_mod.venv_path(tmp_path, "nprep"))
     with pytest.raises(SystemExit):
         campaign_mod.require_env_match(tmp_path, "nprep")
+
+
+def test_require_selected_campaign_bundles_the_three_preconditions(tmp_path, monkeypatch):
+    (tmp_path / ".datalad").mkdir()
+    make_campaign(tmp_path)
+    monkeypatch.setenv(campaign_mod.CAMPAIGN_ENV_VAR, "nprep")
+    pretend_running_in(monkeypatch, campaign_mod.venv_path(tmp_path, "nprep"))
+    study, label, campaign = campaign_mod.require_selected_campaign(tmp_path)
+    assert (study, label, campaign) == (
+        tmp_path.resolve(), "nprep", campaign_mod.campaign_dir(tmp_path, "nprep"))
+
+
+def test_require_selected_campaign_refuses_outside_a_study(tmp_path, monkeypatch):
+    make_campaign(tmp_path)                      # a campaign dir, but no dataset root
+    monkeypatch.setenv(campaign_mod.CAMPAIGN_ENV_VAR, "nprep")
+    with pytest.raises(SystemExit):
+        campaign_mod.require_selected_campaign(tmp_path)

--- a/tests/test_campaign_init.py
+++ b/tests/test_campaign_init.py
@@ -7,6 +7,7 @@ activate script. The real env build is exercised by the `uv_build` integration
 test at the foot of this file.
 """
 
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -38,6 +39,15 @@ def configs(tmp_path):
     return src
 
 
+def pretend_build_env(campaign, label):
+    """What `build_env` leaves behind, without running uv: a stamped venv + a lock."""
+    venv = campaign / campaign_mod.VENV_DIRNAME
+    venv.mkdir()
+    (campaign / campaign_mod.LOCK_FILENAME).write_text("# resolved\n")
+    campaign_mod.write_env_stamp(venv, label, "# resolved\n")
+    return venv
+
+
 @pytest.fixture
 def stub_env(monkeypatch):
     """Stub the env build + datalad save; record that each was asked for.
@@ -48,12 +58,8 @@ def stub_env(monkeypatch):
     calls = {}
 
     def fake_build_env(campaign, label):
-        venv = campaign / campaign_mod.VENV_DIRNAME
-        venv.mkdir()
-        (campaign / campaign_mod.LOCK_FILENAME).write_text("# resolved\n")
-        campaign_mod.write_env_stamp(venv, label, "# resolved\n")
         calls["build_env"] = campaign
-        return venv
+        return pretend_build_env(campaign, label)
 
     def fake_save(study, message, path):
         calls["save"] = (study, message, path)
@@ -125,6 +131,48 @@ def test_the_campaign_is_saved_into_the_study(study, configs, stub_env):
     saved_study, message, path = stub_env["save"]
     assert (saved_study, path) == (study, campaign)
     assert "campaign init nprep" in message
+
+
+# --- git routing ------------------------------------------------------------
+
+def test_the_campaign_declares_its_own_git_routing(study, configs, stub_env):
+    # an attribute on the campaign dir, so it holds for every writer into it — not
+    # a flag one save happens to pass
+    campaign = init(study, configs)
+    assert (campaign / ".gitattributes").read_text() == campaign_init.GITATTRIBUTES
+
+
+def test_campaign_files_land_in_git_not_annex(tmp_path, configs, monkeypatch):
+    """In a real datalad dataset: every campaign file is in git, none annexed.
+
+    The routing is git-annex's decision at add time, so only a real `datalad save`
+    into a real dataset proves the `.gitattributes` does it. Local only — no network.
+    """
+    if shutil.which("git-annex") is None:
+        pytest.skip("git-annex is needed to prove a file was NOT annexed")
+    from datalad.api import Dataset
+
+    root = tmp_path / "real-study"
+    Dataset(str(root)).create(result_renderer="disabled")
+    monkeypatch.setattr(campaign_init, "build_env", pretend_build_env)
+
+    campaign = campaign_init.init(root, "nprep", [str(configs / "MRIQC-24.0.2.yaml")],
+                                  str(configs / "dartmouth.yaml"))
+
+    listing = subprocess.run(
+        ["git", "-C", str(root), "ls-files", "-s", "--", str(campaign.relative_to(root))],
+        capture_output=True, text=True, check=True).stdout.splitlines()
+    entries = {line.split("\t", 1)[1]: line.split()[0] for line in listing}
+    # 120000 is a symlink — how an annexed file is committed
+    annexed = [name for name, mode in entries.items() if mode != "100644"]
+    assert not annexed, f"annexed instead of git: {annexed}"
+    # the attribute file itself is committed, or a clone routes its own writes wrong
+    assert ".mechababs/campaigns/nprep/.gitattributes" in entries
+    assert f".mechababs/campaigns/nprep/{campaign_mod.LOCK_FILENAME}" in entries
+    # the venv is ignored, not committed
+    assert not [name for name in entries if f"/{campaign_mod.VENV_DIRNAME}/" in name]
+    assert subprocess.run(["git", "-C", str(root), "status", "--porcelain"],
+                          capture_output=True, text=True, check=True).stdout == ""
 
 
 # --- the pins ---------------------------------------------------------------

--- a/tests/test_campaign_init.py
+++ b/tests/test_campaign_init.py
@@ -263,7 +263,8 @@ def test_uv_really_locks_and_builds_the_campaign_venv(study, configs, monkeypatc
     mechababs pin is this checkout, so no mechababs release is needed; babs comes
     from its default URL.
     """
-    if subprocess.run(["uv", "--version"], capture_output=True).returncode != 0:
+    if subprocess.run(["uv", "--version"], capture_output=True,
+                      check=False).returncode != 0:
         pytest.skip("uv not available")
     saved = {}
     monkeypatch.setattr(campaign_init, "datalad_save",

--- a/tests/test_campaign_init.py
+++ b/tests/test_campaign_init.py
@@ -9,6 +9,7 @@ test at the foot of this file.
 
 import shutil
 import subprocess
+from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
@@ -61,11 +62,14 @@ def stub_env(monkeypatch):
         calls["build_env"] = campaign
         return pretend_build_env(campaign, label)
 
-    def fake_save(study, message, path):
-        calls["save"] = (study, message, path)
+    @contextmanager
+    def fake_save_scope(root, path):
+        pending = campaign_init.PendingSave()
+        yield pending
+        calls["save"] = (root, pending.message, path)
 
     monkeypatch.setattr(campaign_init, "build_env", fake_build_env)
-    monkeypatch.setattr(campaign_init, "datalad_save", fake_save)
+    monkeypatch.setattr(campaign_init, "campaign_save_scope", fake_save_scope)
     return calls
 
 
@@ -173,6 +177,63 @@ def test_campaign_files_land_in_git_not_annex(tmp_path, configs, monkeypatch):
     assert not [name for name in entries if f"/{campaign_mod.VENV_DIRNAME}/" in name]
     assert subprocess.run(["git", "-C", str(root), "status", "--porcelain"],
                           capture_output=True, text=True, check=True).stdout == ""
+
+
+# --- the save scope ---------------------------------------------------------
+
+@pytest.fixture
+def real_study(tmp_path):
+    """A real datalad dataset — the save scope talks to git, so it needs one."""
+    if shutil.which("git-annex") is None:
+        pytest.skip("git-annex is needed for a real datalad dataset")
+    from datalad.api import Dataset
+
+    root = tmp_path / "real-study"
+    Dataset(str(root)).create(result_renderer="disabled")
+    return root
+
+
+def test_the_save_scope_commits_only_its_own_target(real_study):
+    target = real_study / ".mechababs" / "campaigns" / "nprep"
+    (real_study / "upstream-edit.txt").write_text("someone else's work\n")
+
+    with campaign_init.campaign_save_scope(real_study, target) as save:
+        target.mkdir(parents=True)
+        (target / "campaign.yaml").write_text("label: nprep\n")
+        save.message = "campaign init nprep"
+
+    log = subprocess.run(["git", "-C", str(real_study), "log", "-1", "--format=%s"],
+                         capture_output=True, text=True, check=True).stdout.strip()
+    assert log == "campaign init nprep"
+    # the unrelated edit is still sitting there, untouched and uncommitted
+    assert subprocess.run(["git", "-C", str(real_study), "status", "--porcelain"],
+                          capture_output=True, text=True,
+                          check=True).stdout == "?? upstream-edit.txt\n"
+
+
+def test_the_save_scope_refuses_a_target_that_is_already_dirty(real_study):
+    # add-dataset's case: a hand-edit sitting in the campaign dir would otherwise be
+    # swept into a commit attributed to mechababs
+    target = real_study / ".mechababs" / "campaigns" / "nprep"
+    target.mkdir(parents=True)
+    (target / "hand-edit.yaml").write_text("someone was here\n")
+
+    with pytest.raises(SystemExit) as e:
+        with campaign_init.campaign_save_scope(real_study, target):
+            pass                      # never reached: the guard is at entry
+    assert "hand-edit.yaml" in str(e.value)
+
+
+def test_the_save_scope_ignores_dirt_outside_its_target(real_study):
+    # path-scoped, so a dirty study elsewhere is not this save's problem — and the
+    # check never walks the study's sourcedata
+    target = real_study / ".mechababs" / "campaigns" / "nprep"
+    (real_study / "elsewhere.txt").write_text("dirty\n")
+
+    with campaign_init.campaign_save_scope(real_study, target) as save:
+        target.mkdir(parents=True)
+        (target / "campaign.yaml").write_text("label: nprep\n")
+        save.message = "campaign init nprep"
 
 
 # --- the pins ---------------------------------------------------------------
@@ -325,8 +386,14 @@ def test_uv_really_locks_and_builds_the_campaign_venv(study, configs, monkeypatc
                       check=False).returncode != 0:
         pytest.skip("uv not available")
     saved = {}
-    monkeypatch.setattr(campaign_init, "datalad_save",
-                        lambda s, m, p: saved.update(path=p))
+
+    @contextmanager
+    def fake_save_scope(root, path):
+        pending = campaign_init.PendingSave()
+        yield pending
+        saved["path"] = path
+
+    monkeypatch.setattr(campaign_init, "campaign_save_scope", fake_save_scope)
 
     checkout = Path(__file__).resolve().parent.parent
     branch = subprocess.run(["git", "-C", str(checkout), "rev-parse",

--- a/tests/test_campaign_init.py
+++ b/tests/test_campaign_init.py
@@ -1,0 +1,291 @@
+"""Unit tests for `mechababs campaign init`.
+
+Fast tests stub the two slow, outside-world steps — the uv env build and the
+datalad save — and assert on the campaign's *contents*: the copied configs, the
+pins written into pyproject.toml, the header-only statefile, and the select +
+activate script. The real env build is exercised by the `uv_build` integration
+test at the foot of this file.
+"""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+from mechababs import campaign as campaign_mod
+from mechababs import campaign_init
+
+
+@pytest.fixture
+def study(tmp_path):
+    """A study root, minimal: mechababs only requires it to be a dataset."""
+    root = tmp_path / "study-ds000001"
+    (root / ".datalad").mkdir(parents=True)
+    return root
+
+
+@pytest.fixture
+def configs(tmp_path):
+    """The user's own app + cluster configs, somewhere outside the study."""
+    src = tmp_path / "my-configs"
+    src.mkdir()
+    (src / "MRIQC-24.0.2.yaml").write_text("bids_app_args: {}\n")
+    (src / "fMRIPrep-25.2.5+anat.yaml").write_text("bids_app_args: {}\n")
+    (src / "fMRIPrep-25.2.5+minimal.yaml").write_text(
+        "mechababs:\n  depends_on: fMRIPrep-25.2.5+anat\n")
+    (src / "dartmouth.yaml").write_text("cluster_resources: {}\n")
+    return src
+
+
+@pytest.fixture
+def stub_env(monkeypatch):
+    """Stub the env build + datalad save; record that each was asked for.
+
+    Both reach outside the process (uv resolves over the network; datalad commits
+    in a real dataset), and neither is what these tests are about.
+    """
+    calls = {}
+
+    def fake_build_env(campaign, label):
+        venv = campaign / campaign_mod.VENV_DIRNAME
+        venv.mkdir()
+        (campaign / campaign_mod.LOCK_FILENAME).write_text("# resolved\n")
+        campaign_mod.write_env_stamp(venv, label, "# resolved\n")
+        calls["build_env"] = campaign
+        return venv
+
+    def fake_save(study, message, path):
+        calls["save"] = (study, message, path)
+
+    monkeypatch.setattr(campaign_init, "build_env", fake_build_env)
+    monkeypatch.setattr(campaign_init, "datalad_save", fake_save)
+    return calls
+
+
+def init(study, configs, *names, label="nprep", **kwargs):
+    apps = [str(configs / f"{n}.yaml") for n in names] or \
+        [str(configs / "MRIQC-24.0.2.yaml")]
+    return campaign_init.init(study, label, apps, str(configs / "dartmouth.yaml"),
+                              **kwargs)
+
+
+# --- the campaign's contents ------------------------------------------------
+
+def test_init_writes_the_campaign_layout(study, configs, stub_env):
+    campaign = init(study, configs, "MRIQC-24.0.2", "fMRIPrep-25.2.5+anat")
+
+    assert campaign == study / ".mechababs" / "campaigns" / "nprep"
+    for name in (campaign_mod.CONFIG_FILENAME, campaign_mod.STATE_FILENAME,
+                 campaign_mod.ENV_FILENAME, campaign_mod.PYPROJECT_FILENAME):
+        assert (campaign / name).is_file(), name
+    # the configs are COPIED in — the run reproduces from the study alone
+    assert (campaign / "bids-app-configs" / "MRIQC-24.0.2.yaml").is_file()
+    assert (campaign / "clusters" / "dartmouth.yaml").is_file()
+
+
+def test_the_statefile_is_header_only(study, configs, stub_env):
+    # which source datasets a campaign acts on is add-dataset's explicit selection
+    campaign = init(study, configs)
+    assert (campaign / campaign_mod.STATE_FILENAME).read_text() == \
+        campaign_mod.initial_header()
+
+
+def test_campaign_yaml_records_the_bundle_order_cluster_and_limit(study, configs, stub_env):
+    campaign = init(study, configs, "fMRIPrep-25.2.5+anat", "MRIQC-24.0.2", limit=1)
+    config = yaml.safe_load((campaign / campaign_mod.CONFIG_FILENAME).read_text())
+    assert config == {
+        "label": "nprep",
+        "apps": ["bids-app-configs/fMRIPrep-25.2.5+anat.yaml",
+                 "bids-app-configs/MRIQC-24.0.2.yaml"],
+        "cluster": "clusters/dartmouth.yaml",
+        "limit": 1,
+    }
+
+
+def test_the_venv_is_gitignored_from_inside_the_campaign(study, configs, stub_env):
+    # mechababs' footprint stays under .mechababs/; the study's own .gitignore is
+    # upstream's and is not touched
+    campaign = init(study, configs)
+    assert (campaign / ".gitignore").read_text() == ".venv/\n"
+    assert not (study / ".gitignore").exists()
+
+
+def test_env_sh_selects_the_campaign_and_activates_its_venv(study, configs, stub_env):
+    campaign = init(study, configs)
+    env_sh = (campaign / campaign_mod.ENV_FILENAME).read_text()
+    assert "export MECHABABS_CAMPAIGN='nprep'" in env_sh
+    assert ".venv/bin/activate" in env_sh
+    # no absolute path: env.sh is committed and must work from any clone
+    assert str(study) not in env_sh
+
+
+def test_the_campaign_is_saved_into_the_study(study, configs, stub_env):
+    campaign = init(study, configs)
+    saved_study, message, path = stub_env["save"]
+    assert (saved_study, path) == (study, campaign)
+    assert "campaign init nprep" in message
+
+
+# --- the pins ---------------------------------------------------------------
+
+def test_pyproject_pins_mechababs_and_babs_by_ref(study, configs, stub_env):
+    campaign = init(study, configs,
+                    babs_spec="https://github.com/PennLINC/babs.git@v0.5.0",
+                    mechababs_spec="https://github.com/con/mechababs.git@v0.2")
+    pyproject = (campaign / campaign_mod.PYPROJECT_FILENAME).read_text()
+    assert 'babs = { git = "https://github.com/PennLINC/babs.git", rev = "v0.5.0" }' \
+        in pyproject
+    assert 'mechababs = { git = "https://github.com/con/mechababs.git", rev = "v0.2" }' \
+        in pyproject
+    # a virtual project: the campaign is dependencies to resolve, not a package to build
+    assert "[build-system]" not in pyproject
+
+
+def test_a_local_checkout_pin_becomes_a_file_url(tmp_path):
+    # dev mode: run a whole campaign against a branch that exists only on disk
+    checkout = tmp_path / "babs-checkout"
+    checkout.mkdir()
+    assert campaign_init.git_source(str(checkout), "my-branch") == {
+        "git": checkout.resolve().as_uri(), "rev": "my-branch"}
+
+
+def test_a_git_plus_url_is_normalised(tmp_path):
+    assert campaign_init.git_source("git+https://x/y.git", "main")["git"] == \
+        "https://x/y.git"
+
+
+def test_a_pin_without_a_ref_is_refused():
+    with pytest.raises(SystemExit):
+        campaign_init.parse_source_spec("https://github.com/PennLINC/babs.git", "babs")
+
+
+def test_the_running_mechababs_is_pinned_by_its_resolved_commit(monkeypatch):
+    class FakeDist:
+        version = "0.2"
+
+        def read_text(self, name):
+            return ('{"url": "https://github.com/con/mechababs",'
+                    ' "vcs_info": {"vcs": "git", "requested_revision": "v0.2",'
+                    ' "commit_id": "9f3c1a2"}}')
+
+    monkeypatch.setattr(campaign_init.metadata, "distribution", lambda n: FakeDist())
+    # the commit, not the branch: the campaign records exactly what ran
+    assert campaign_init.running_mechababs_pin() == (
+        "mechababs", {"git": "https://github.com/con/mechababs", "rev": "9f3c1a2"})
+
+
+def test_an_editable_mechababs_is_pinned_by_path(monkeypatch):
+    class FakeDist:
+        version = "0.2"
+
+        def read_text(self, name):
+            return ('{"url": "file:///home/dev/mechababs",'
+                    ' "dir_info": {"editable": true}}')
+
+    monkeypatch.setattr(campaign_init.metadata, "distribution", lambda n: FakeDist())
+    assert campaign_init.running_mechababs_pin() == (
+        "mechababs", {"path": "/home/dev/mechababs", "editable": True})
+
+
+def test_a_released_mechababs_is_pinned_by_version(monkeypatch):
+    class FakeDist:
+        version = "0.2.1"
+
+        def read_text(self, name):
+            return None            # a registry install has no direct_url.json
+
+    monkeypatch.setattr(campaign_init.metadata, "distribution", lambda n: FakeDist())
+    assert campaign_init.running_mechababs_pin() == ("mechababs==0.2.1", None)
+
+
+# --- refusals ---------------------------------------------------------------
+
+def test_init_refuses_a_second_campaign_under_the_same_label(study, configs, stub_env):
+    init(study, configs)
+    with pytest.raises(SystemExit):
+        init(study, configs)
+
+
+def test_init_refuses_a_duplicate_app_name_before_copying_anything(study, configs,
+                                                                   stub_env, tmp_path):
+    other = tmp_path / "other"
+    other.mkdir()
+    (other / "MRIQC-24.0.2.yaml").write_text("bids_app_args: {x: 1}\n")
+    with pytest.raises(SystemExit):
+        campaign_init.init(study, "nprep",
+                           [str(configs / "MRIQC-24.0.2.yaml"),
+                            str(other / "MRIQC-24.0.2.yaml")],
+                           str(configs / "dartmouth.yaml"))
+    assert not (campaign_mod.apps_dir(study, "nprep") / "MRIQC-24.0.2.yaml").exists()
+
+
+def test_init_refuses_a_depends_on_outside_the_bundle(study, configs, stub_env):
+    # fMRIPrep-minimal depends on fMRIPrep-anat, which is not in this bundle
+    with pytest.raises(SystemExit) as e:
+        init(study, configs, "MRIQC-24.0.2", "fMRIPrep-25.2.5+minimal")
+    assert "depends_on" in str(e.value)
+
+
+def test_init_accepts_a_declared_dependency_that_is_in_the_bundle(study, configs,
+                                                                  stub_env):
+    campaign = init(study, configs, "fMRIPrep-25.2.5+anat", "fMRIPrep-25.2.5+minimal")
+    assert campaign_init.declared_depends_on(
+        campaign / "bids-app-configs" / "fMRIPrep-25.2.5+minimal.yaml"
+    ) == "fMRIPrep-25.2.5+anat"
+
+
+def test_init_refuses_a_config_that_is_not_there(study, configs, stub_env):
+    # a bare name is NOT resolved against some directory mechababs knows about
+    with pytest.raises(SystemExit):
+        campaign_init.init(study, "nprep", ["MRIQC-24.0.2.yaml"],
+                           str(configs / "dartmouth.yaml"))
+
+
+def test_init_refuses_an_unusable_label(study, configs, stub_env):
+    with pytest.raises(SystemExit):
+        init(study, configs, label="../escape")
+
+
+def test_init_refuses_outside_a_study(tmp_path, configs, stub_env):
+    from mechababs import study as study_mod
+    with pytest.raises(SystemExit):
+        study_mod.require_study_root(tmp_path / "not-a-study")
+
+
+# --- the real environment build ---------------------------------------------
+
+@pytest.mark.uv_build
+def test_uv_really_locks_and_builds_the_campaign_venv(study, configs, monkeypatch):
+    """The env build for real: uv resolves the lock and syncs a venv from it.
+
+    Marked so the fast suite skips it — it runs `uv` and reaches the network. The
+    mechababs pin is this checkout, so no mechababs release is needed; babs comes
+    from its default URL.
+    """
+    if subprocess.run(["uv", "--version"], capture_output=True).returncode != 0:
+        pytest.skip("uv not available")
+    saved = {}
+    monkeypatch.setattr(campaign_init, "datalad_save",
+                        lambda s, m, p: saved.update(path=p))
+
+    checkout = Path(__file__).resolve().parent.parent
+    branch = subprocess.run(["git", "-C", str(checkout), "rev-parse",
+                             "--abbrev-ref", "HEAD"],
+                            capture_output=True, text=True, check=True).stdout.strip()
+    campaign = campaign_init.init(
+        study, "nprep", [str(configs / "MRIQC-24.0.2.yaml")],
+        str(configs / "dartmouth.yaml"),
+        mechababs_spec=f"{checkout}@{branch}",
+    )
+
+    lock = (campaign / campaign_mod.LOCK_FILENAME).read_text()
+    assert 'name = "babs"' in lock and 'name = "mechababs"' in lock
+    # the venv is where env.sh will look, and stamped with the lock that built it
+    venv = campaign / campaign_mod.VENV_DIRNAME
+    assert (venv / "bin" / "mechababs").exists()
+    assert campaign_mod.read_env_stamp(venv)["lock_sha256"] == \
+        campaign_mod.lock_digest(lock)
+    # ... so the env-match guard passes against it
+    monkeypatch.setattr("sys.prefix", str(venv))
+    campaign_mod.require_env_match(study, "nprep")

--- a/tests/test_campaign_init.py
+++ b/tests/test_campaign_init.py
@@ -129,6 +129,16 @@ def test_the_campaign_is_saved_into_the_study(study, configs, stub_env):
 
 # --- the pins ---------------------------------------------------------------
 
+def test_babs_defaults_to_the_released_version_from_pypi(study, configs, stub_env):
+    # no --babs: a plain dependency with no source entry, so uv resolves the latest
+    # release and the lock freezes the exact version. Git is the override, not the default.
+    campaign = init(study, configs)
+    pyproject = (campaign / campaign_mod.PYPROJECT_FILENAME).read_text()
+    assert '    "babs",' in pyproject
+    sources = pyproject.partition("[tool.uv.sources]")[2].splitlines()
+    assert not [line for line in sources if line.startswith("babs = ")]
+
+
 def test_pyproject_pins_mechababs_and_babs_by_ref(study, configs, stub_env):
     campaign = init(study, configs,
                     babs_spec="https://github.com/PennLINC/babs.git@v0.5.0",
@@ -261,7 +271,7 @@ def test_uv_really_locks_and_builds_the_campaign_venv(study, configs, monkeypatc
 
     Marked so the fast suite skips it — it runs `uv` and reaches the network. The
     mechababs pin is this checkout, so no mechababs release is needed; babs comes
-    from its default URL.
+    from PyPI, its default.
     """
     if subprocess.run(["uv", "--version"], capture_output=True,
                       check=False).returncode != 0:

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -1,0 +1,34 @@
+"""Unit tests for the study-root check.
+
+Study-first: every command operates inside a study that already exists, so the
+wrong-directory mistake is caught once, here, rather than as a confusing failure
+deeper in.
+"""
+
+import pytest
+
+from mechababs import study as study_mod
+
+
+def test_a_datalad_dataset_is_a_study_root(tmp_path):
+    (tmp_path / ".datalad").mkdir()
+    assert study_mod.is_study_root(tmp_path)
+    assert study_mod.require_study_root(tmp_path) == tmp_path.resolve()
+
+
+def test_a_plain_git_repo_counts(tmp_path):
+    # fixture studies (and the e2e's fabricated one) are plain git repos
+    (tmp_path / ".git").mkdir()
+    assert study_mod.is_study_root(tmp_path)
+
+
+def test_a_worktree_git_file_counts(tmp_path):
+    # a git worktree's .git is a FILE, not a dir
+    (tmp_path / ".git").write_text("gitdir: /elsewhere/.git/worktrees/x\n")
+    assert study_mod.is_study_root(tmp_path)
+
+
+def test_a_bare_directory_is_not_a_study(tmp_path):
+    assert not study_mod.is_study_root(tmp_path)
+    with pytest.raises(SystemExit):
+        study_mod.require_study_root(tmp_path)


### PR DESCRIPTION
tldr:

- New command: `mechababs campaign init <label> --apps <paths/urls> --cluster <path/url> [--limit N]` — creates a campaign (one config epoch) inside an existing study, per `docs/spec.md`.
- Writes `.mechababs/campaigns/<label>/`: the user's configs copied in, `pyproject.toml` + `uv.lock` pinning mechababs + babs, `env.sh`, and the empty tall statefile — then builds the campaign venv from the lock.
- Selection is always `MECHABABS_CAMPAIGN`: one `source env.sh` selects the campaign and activates its venv; an env-match guard refuses to operate when the venv and the committed lock disagree.
- babs defaults to its PyPI release (frozen to an exact version by the lock); `--babs URL@REF` pins a git checkout instead. mechababs pins itself from the running install, so `uvx --from git+…` records the resolved commit.
- datalad is floored at >=1.6: released 1.4 silently drops `datalad run` records when the wrapped command commits its own work (spike-verified).
- 101 unit tests, network-free by default. The pre-study-first verbs (`configure`/`bootstrap.sh`/`iterate`) are untouched and still work.

<details><summary>The campaign directory, file by file</summary>

```
.mechababs/campaigns/<label>/
  campaign.yaml               the ordered app bundle + cluster choice + limit
  bids-app-configs/           the app configs, copied in (path or URL — never a bare name)
  clusters/                   the cluster config, copied in
  env.sh                      committed; sets MECHABABS_CAMPAIGN + activates the venv, relative to its own location
  pyproject.toml              declares mechababs + babs (+ campaign extras: con-duct, visidata, pytest)
  uv.lock                     the resolved environment — the provenance record
  sourcedata+derivatives.tsv  the tall statefile, header-only (add-dataset writes rows)
  .gitattributes              routes everything here into git, not annex (annex.largefiles=nothing)
  .gitignore                  ignores .venv/ from inside the campaign dir — the study's own files are never touched
  .venv/                      gitignored, rebuilt from the lock
```

The copy is the point: the config and lock that produced a run are committed in the study, so the run reproduces from the study alone.
`inclusions/` is not created here — git can't track an empty dir; scaffold creates it with the first pin.
</details>

<details><summary>How the pins work</summary>

**mechababs** is pinned from the running install's PEP 610 `direct_url.json`: a git install (the `uvx --from git+…` case) records the **resolved commit**, not the branch name; a local/editable checkout records the path (honest, non-portable dev mode); a registry install records `mechababs==<version>`. `--mechababs URL@REF` overrides; running from a bare un-installed checkout refuses, naming the flag (an unsourced requirement would otherwise send uv to PyPI, where mechababs does not exist — a release is #113).

**babs** defaults to a plain dependency — uv resolves the latest PyPI release and the lock freezes the exact version. `--babs URL@REF` (URL is anything git clones, a local path included) becomes a `[tool.uv.sources]` git entry: how a PR branch, or a branch that exists only on disk, runs through a whole campaign. babs main is far ahead of its release, so real campaigns will often override — deliberately, visibly.

The generated `pyproject.toml` is a uv **virtual project** (no `[build-system]`): uv resolves and installs the dependencies but never tries to build the campaign dir itself as a package.
</details>

<details><summary>The env-match guard</summary>

Factored once (`campaign.require_selected_campaign`) for every later operating verb, two checks: `sys.prefix` must be this campaign's venv (the wrong-babs killer, re-homed from today's CLI guard), and a stamp written into the venv at build time (the lock's sha256) must match the **committed** `uv.lock` — catching both a bumped-but-not-rebuilt lock and a rebuilt-then-reverted one. The refusal names `mechababs campaign update-env` (a later chunk) as the fix. The stamp lives inside the venv, so it is gitignored by construction and cannot outlive the environment it describes.
</details>

<details><summary>How init commits: a clean-in, path-scoped save scope — not datalad run</summary>

The spec's `datalad run` capture covers the transition verbs `iterate` dispatches. `campaign init` is not one of them, and a uvx-invoked command is not re-executable from inside the campaign — the tool it names isn't installed yet; that chicken-and-egg is what this command exists to resolve.

So init's whole body runs inside `campaign_save_scope(root, path)`: **clean in** (the target path must be clean before the block writes, so the commit is attributable and never absorbs an edit mechababs didn't make — path-scoped, hence cheap: the campaign dir holds no subdatasets), **one commit out** via `datalad.api` (a shelled-out `datalad` would have fallen back to whatever PATH held — under uvx there is no `bin/datalad` beside the interpreter, so the fallback would always have fired). Files land in git rather than annex because init scaffolds a `.gitattributes` (`* annex.largefiles=nothing`) as the campaign dir's first file — declarative routing for this save and every future writer, instead of a per-call `--to-git` flag that becomes a footgun the first time the helper meets a real subdataset.
</details>

<details><summary>Verification</summary>

`.venv/bin/python -m pytest -q` → 101 passed, 1 deselected. The deselected `uv_build`-marked test really runs `uv lock` + `uv sync` (needs uv + network) and passes.

Hand-verified beyond the suite: the literal quickstart command (`uvx --from git+…@<ref> mechababs campaign init …`) in a fresh `datalad create`d study — resolved commit recorded in the pyproject, working tree clean afterwards, every campaign file in git not annex; `source env.sh` under bash, zsh, and dash; both guard refusals fired against a real campaign venv.
</details>

<details><summary>Scope notes — and why this PR removes nothing</summary>

Later chunks, not here: `--superstudy`, the new `add-dataset`, `iterate`/scaffold/submit/merge, `campaign update-env`, the `test-cluster` re-point.

This PR is deliberately additive. The pre-study-first path (`bootstrap.sh → configure → add-dataset → iterate`) is what the e2e exercises, so it stays runnable as the sprint's regression guard while chunks land — and `configure` isn't fully replaced yet (its container vendoring has no new home until scaffold). **Removal is the e2e-re-point chunk's explicit second deliverable**: one PR whose diff shows the e2e switched to the study-first path and the old path deleted, green together. What this PR obsoletes is already on that deletion list: `bootstrap.sh`, `configure` (`construct.build`), the old CLI venv guard, `requirements-campaign.txt` (extras become package data at deletion time).
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
