### PR TITLE
env: declare the Python ceiling babs' numpy pin already imposes

### DIFF
--- a/mechababs/campaign_init.py
+++ b/mechababs/campaign_init.py
@@ -322,7 +322,13 @@ def render_pyproject(
         "[project]",
         f"name = {_toml_str('mechababs-campaign-' + label)}",
         'version = "0"',
-        'requires-python = ">=3.10"',
+        # TEMPORARY, drop to ">=3.10" when PennLINC/babs#403 lifts babs' numpy pin.
+        # The reason is emitted into the file itself: a user reading their own
+        # campaign's pyproject should not have to guess why 3.13 is excluded.
+        "# The upper bound is babs' `numpy < 2.0` pin: numpy 1.26.4 has no wheel past",
+        "# cp312, so 3.13+ falls back to a source build that fails. Tracked upstream as",
+        "# PennLINC/babs#403; the bound goes away when that pin lifts.",
+        'requires-python = ">=3.10,<3.13"',
         "dependencies = [",
     ]
     lines += [f"    {_toml_str(d)}," for d in deps]


### PR DESCRIPTION
tldr:
- babs pins `numpy < 2.0`; numpy 1.26.4 ships no wheel past cp312, so a campaign env cannot be built on Python 3.13+ (F44 ships 3.14 only).
- The generated campaign pyproject now declares `requires-python = ">=3.10,<3.13"`, so uv says "No interpreter found" and names the `uv python install` fix instead of emitting a wall of meson output.
- Declares the constraint, does not fix it. Temporary: goes away when PennLINC/babs#403 lifts the pin upstream.

<details><summary>Why not <code>env_constraints</code></summary>

It takes PEP 508 *package* specifiers, so a `python<=3.12` entry there is accepted and silently does nothing (verified). The spec also scopes that field to site facts, and this one holds on every machine.

</details>
