### PR TITLE
campaign init takes the level's single-writer lock

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -47,6 +47,7 @@ Which source datasets the campaign acts on is a separate step, `add-dataset`.
 
 Init never clobbers, and it does not scaffold input studies.
 What it does is decided by what is at the target: nothing there, and `--superstudy` given, creates the superstudy as a datalad dataset and the campaign inside it (a study is never created this way); an existing datalad dataset gains a `.mechababs/` at its root, with any campaigns already there untouched; a non-empty directory that is not a dataset is refused; a campaign with this label already present is refused, by name.
+Init commits at the study or superstudy root, so it holds the level's single-writer lock like every other command that does, and cannot land while an iterate there is mid-save.
 
 At a superstudy, `campaign init` touches only the superstudy's own campaign dir.
 A member study gets its copy of the campaign (configs, `pyproject.toml`, `uv.lock`, an empty statefile) when `add-dataset` first selects a source dataset in it; the venv and `env.sh` exist only at the superstudy.

--- a/mechababs/campaign_init.py
+++ b/mechababs/campaign_init.py
@@ -43,7 +43,7 @@ from datalad.api import Dataset
 
 from mechababs import campaign as campaign_mod
 from mechababs import study as study_mod
-from mechababs.utils import campaign_save_scope
+from mechababs.utils import campaign_save_scope, flocked
 
 # Runtime tools a campaign needs beyond mechababs + babs themselves. A literal rather
 # than a requirements file in the repo, because this command may run from an ephemeral
@@ -574,13 +574,23 @@ def init(
     if not app_args:
         sys.exit("--apps must name at least one BIDS-App config")
 
+    # The level's single-writer lock, held across the write and the save: init
+    # commits at the study root, where a tick or an add-dataset may be mid-save.
+    # The lock lives under .mechababs/, so on a fresh study that dir is created
+    # first; the lock file itself is not yet ignored at that moment, but the scope
+    # below is path-scoped to what init declares, so it is neither checked nor
+    # swept in.
+    level_gitignore = campaign_mod.level_gitignore_path(study)
+    level_gitignore.parent.mkdir(exist_ok=True)
     # Everything that writes runs inside the scope: it checks the target is clean
     # first, and commits what the block produced as one attributable node. Two paths
     # declared: the campaign dir, and the level's .gitignore under .mechababs/ —
     # shared by every campaign at this level, so a second init finds it committed
     # and the save has nothing to record for it.
-    level_gitignore = campaign_mod.level_gitignore_path(study)
-    with campaign_save_scope(study, [campaign, level_gitignore]) as save:
+    with (
+        flocked(campaign_mod.flock_path(study)),
+        campaign_save_scope(study, [campaign, level_gitignore]) as save,
+    ):
         campaign.mkdir(parents=True)
 
         # First file in, before anything it has to govern: git-annex reads the
@@ -593,10 +603,12 @@ def init(
         # alone — untracked-but-not-ignored files would dirty the study, which the
         # clean-in guards read as unattributable work. The flock belongs to the
         # LEVEL (every campaign here takes the same one), so it is ignored from
-        # .mechababs/ itself; written idempotently, since .mechababs/ may already
-        # carry earlier campaigns. The venv is this campaign's, ephemeral and
-        # rebuilt from the lock, and is ignored from inside its own dir.
-        level_gitignore.write_text(f"{campaign_mod.FLOCK_FILENAME}\n")
+        # .mechababs/ itself — written by the first init here and left alone by
+        # every later one: the file is shared, and may carry a user's own lines.
+        # The venv is this campaign's, ephemeral and rebuilt from the lock, and is
+        # ignored from inside its own dir.
+        if not level_gitignore.exists():
+            level_gitignore.write_text(f"{campaign_mod.FLOCK_FILENAME}\n")
         (campaign / ".gitignore").write_text(f"{campaign_mod.VENV_DIRNAME}/\n")
 
         apps = resolve_apps(campaign / campaign_mod.APPS_DIRNAME, app_args)

--- a/tests/test_campaign_init.py
+++ b/tests/test_campaign_init.py
@@ -169,6 +169,54 @@ def test_the_campaign_is_saved_into_the_study(study, configs, stub_env):
     assert "campaign init nprep" in message
 
 
+def test_init_holds_the_level_flock_across_the_save(
+    study, configs, stub_env, monkeypatch
+):
+    """Init commits at the study root, where a tick or an add-dataset may be
+    mid-save, so it is a writer like the rest and takes the level's lock — around
+    the save, not just the writes, since the save is the collision."""
+    events = []
+    real_flocked = campaign_init.flocked
+
+    @contextmanager
+    def watching_flock(lock):
+        with real_flocked(lock):
+            events.append(("locked", Path(lock)))
+            yield
+            events.append(("released", Path(lock)))
+
+    stubbed_save = campaign_init.campaign_save_scope
+
+    @contextmanager
+    def watching_save(root, paths):
+        with stubbed_save(root, paths) as save:
+            yield save
+        events.append(("saved", root))
+
+    monkeypatch.setattr(campaign_init, "flocked", watching_flock)
+    monkeypatch.setattr(campaign_init, "campaign_save_scope", watching_save)
+
+    init(study, configs)
+
+    lock = campaign_mod.flock_path(study)
+    assert events == [("locked", lock), ("saved", study), ("released", lock)]
+
+
+def test_a_later_init_leaves_the_level_gitignore_alone(study, configs, stub_env):
+    """The level's .gitignore is shared by every campaign here and may carry a
+    user's own lines: the first init writes it, later ones do not touch it."""
+    init(study, configs, label="first")
+    gitignore = campaign_mod.level_gitignore_path(study)
+    gitignore.write_text(f"{campaign_mod.FLOCK_FILENAME}\nmy-scratch/\n")
+
+    campaign = init(study, configs, label="second")
+
+    assert gitignore.read_text() == f"{campaign_mod.FLOCK_FILENAME}\nmy-scratch/\n"
+    # still declared: a user's uncommitted edit to it is refused, not swept in
+    _, _, paths = stub_env["save"]
+    assert paths == [campaign, gitignore]
+
+
 # --- git routing ------------------------------------------------------------
 
 


### PR DESCRIPTION
`campaign init` commits at the study or superstudy root, where a tick or an `add-dataset` may be mid-save. The spec (line 77) says the single-writer lock is held for the whole of any command that mutates git state; init was the one command that did not take it. This makes the code true rather than carving an exception into the sentence. The last code blocker on #114 besides the audits.

- `init` holds `flocked(flock_path(study))` around its save scope. `.mechababs/` is created first so the lock has a home on a fresh study; the scope stays path-scoped to what init declares, so the not-yet-ignored lock file is neither checked nor swept in.
- The level's `.gitignore` is written only when absent. It is shared by every campaign at the level and may carry a user's own lines, so a later init leaves it alone. It stays declared in the save scope, so an uncommitted user edit is refused rather than swept in.
- No healing: a deleted lock file comes back on the next `flocked()`; a lock no longer ignored is drift the clean-in check refuses like any other.
- One sentence in `docs/reference.md` under `campaign init`.

Verified: unit suite 419 passed locally; ruff, unit, uv-contract and e2e run in CI on the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PoqYnCfY83RfY9qJhcvKV
